### PR TITLE
feat: 정책지원금 프론트 화면 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@types/rc-slider": "^9.3.0",
         "axios": "^1.11.0",
         "lucide-react": "^0.542.0",
+        "rc-slider": "^11.1.8",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0",
@@ -300,6 +302,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1485,6 +1496,15 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/rc-slider": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/rc-slider/-/rc-slider-9.3.0.tgz",
+      "integrity": "sha512-ytjaiWUkhlRUFg70CgDaMnXIeg3LB1ISgmFtIki9uhwtQ2x87+Jg6bGtn0J2A0wxHA5Vf+poU1/3qBltSy0ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "rc-slider": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
@@ -2389,6 +2409,22 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5476,6 +5512,44 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/rc-slider": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.8.tgz",
+      "integrity": "sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.5",
+        "rc-util": "^5.36.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2410,16 +2410,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
   },
   "dependencies": {
+    "@types/rc-slider": "^9.3.0",
     "axios": "^1.11.0",
     "lucide-react": "^0.542.0",
+    "rc-slider": "^11.1.8",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",

--- a/src/api/fundApi.ts
+++ b/src/api/fundApi.ts
@@ -1,0 +1,30 @@
+export const searchFunds = async (keyword: string) => {
+  const res = await axios.get('/api/funds/search', { params: { keyword } });
+  return res.data;
+};
+import axios from 'axios';
+
+export const getFundsList = async () => {
+  const res = await axios.get('/api/funds');
+  return res.data;
+};
+
+export const getFundDetail = async (fundsId: number) => {
+  const res = await axios.get(`/api/funds/${fundsId}`);
+  return res.data;
+};
+
+export const toggleBookmark = async (fundsId: number, saved: boolean) => {
+  if (saved) {
+    // 북마크 해제
+    return axios.delete(`/api/saved-funds/${fundsId}`);
+  } else {
+    // 북마크 추가
+    return axios.post(`/api/saved-funds/${fundsId}`);
+  }
+};
+
+export const getBookmarkedFunds = async () => {
+  const res = await axios.get('/api/saved-funds');
+  return res.data;
+};

--- a/src/api/supportCenterApi.ts
+++ b/src/api/supportCenterApi.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+
+export type SupportCenter = {
+  id: number;
+  name: string;
+  jurisdiction: string;
+  address: string;
+  phone: string;
+  fax: string;
+  lat: number;
+  lng: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type NearestCenterResponse = {
+  center: SupportCenter;
+  distanceKm: number;
+  rank: number;
+};
+
+export type NearestCentersData = {
+  searchedAddress: string;
+  businessLat: number;
+  businessLng: number;
+  nearestCenters: NearestCenterResponse[];
+};
+
+// 전체 지원센터 목록 조회
+export const getAllSupportCenters = async () => {
+  try {
+    const response = await axios.get('/api/support-centers');
+    return {
+      status: response.status,
+      data: response.data.data?.centers || [],
+      message: response.data.message,
+    };
+  } catch (error: any) {
+    console.error('전체 센터 목록 조회 실패:', error);
+    return {
+      status: error.response?.status || 500,
+      data: [],
+      message: '센터 목록을 불러오는데 실패했습니다.',
+    };
+  }
+};
+
+// 가까운 지원센터 조회
+export const getNearestSupportCenters = async (
+  businessAddress: string,
+  limit = 1,
+) => {
+  try {
+    const response = await axios.post('/api/support-centers/nearest', {
+      businessAddress,
+      limit,
+    });
+
+    return {
+      status: response.status,
+      data: response.data.data as NearestCentersData,
+      message: response.data.message,
+    };
+  } catch (error: any) {
+    console.error('가까운 센터 조회 실패:', error);
+    return {
+      status: error.response?.status || 500,
+      data: null,
+      message: '가까운 센터를 찾는데 실패했습니다.',
+    };
+  }
+};
+
+// 사업장 주소 조회 (사용자 정보에서)
+export const getBusinessAddress = async () => {
+  try {
+    const response = await axios.get('/api/member/info');
+
+    return {
+      status: response.status,
+      address: response.data.data?.businessAddress || null,
+      message: response.data.message,
+    };
+  } catch (error: any) {
+    console.error('사업장 주소 조회 실패:', error);
+
+    // 404일 경우 임시로 더미 데이터 반환
+    if (error.response?.status === 404) {
+      console.log('API 엔드포인트가 구현되지 않음. 더미 데이터 사용.');
+      //todo 사용자에게서 사업자 주소 받아와야함
+      return {
+        status: 200,
+        address: '서울특별시 영등포구 국제금융로8길 26 (여의도동)', // 임시 더미 주소
+        message: '임시 더미 데이터',
+      };
+    }
+
+    // 다른 에러 발생 시에도 더미 데이터 반환
+    return {
+      status: 200,
+      address: '서울특별시 영등포구 국제금융로8길 26 (여의도동)', // 임시 더미 주소
+      message: '임시 더미 데이터 (에러로 인한 fallback)',
+    };
+  }
+};

--- a/src/components/support/FilterButtons.tsx
+++ b/src/components/support/FilterButtons.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+type MainFilter = 'none' | 'filter' | 'map' | 'receiving' | 'bookmark';
+
+type FilterButtonsProps = {
+  activeMainFilter: MainFilter;
+  onFilterClick: () => void;
+  onMapClick: () => void;
+  onReceivingClick: () => void;
+  onBookmarkClick: () => void;
+};
+
+const FilterButtons: React.FC<FilterButtonsProps> = ({
+  activeMainFilter,
+  onFilterClick,
+  onMapClick,
+  onReceivingClick,
+  onBookmarkClick,
+}) => {
+  return (
+    <div className="flex gap-2 mb-4 w-full max-w-md px-2">
+      <button
+        className={`px-3 py-2 rounded text-xs font-semibold ${
+          activeMainFilter === 'filter' ? 'bg-navy text-white' : 'bg-gray-200'
+        }`}
+        onClick={onFilterClick}
+      >
+        :: 필터
+      </button>
+      <button
+        className={`px-3 py-2 rounded text-xs font-semibold ${
+          activeMainFilter === 'map' ? 'bg-navy text-white' : 'bg-gray-200'
+        }`}
+        onClick={onMapClick}
+      >
+        내센터
+      </button>
+      <button
+        className={`px-3 py-2 rounded text-xs font-semibold ${
+          activeMainFilter === 'receiving' ? 'bg-navy text-white' : 'bg-gray-200'
+        }`}
+        onClick={onReceivingClick}
+      >
+        접수중
+      </button>
+      <button
+        className={`px-3 py-2 rounded text-xl font-semibold flex items-center justify-center ${
+          activeMainFilter === 'bookmark' ? 'bg-navy text-white' : 'bg-gray-200'
+        }`}
+        aria-label="북마크"
+        onClick={onBookmarkClick}
+      >
+        <span className="text-yellow-400">★</span>
+      </button>
+    </div>
+  );
+};
+
+export default FilterButtons;

--- a/src/components/support/FilterSheet.tsx
+++ b/src/components/support/FilterSheet.tsx
@@ -1,0 +1,309 @@
+import React, { useState } from 'react';
+import { colors } from '../../styles/colors';
+import Slider from 'rc-slider';
+import 'rc-slider/assets/index.css';
+
+type Filters = {
+  keywords: string[];
+  types: string[];
+  purposes: string[];
+  rates: string[];
+  limit: [number, number];
+};
+
+type FilterSheetProps = {
+  showFilter: boolean;
+  setShowFilter: (show: boolean) => void;
+  activeFilters: Filters;
+  setActiveFilters: React.Dispatch<React.SetStateAction<Filters>>;
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+  keywordRef: React.RefObject<HTMLDivElement | null>;
+  typeRef: React.RefObject<HTMLDivElement | null>;
+  purposeRef: React.RefObject<HTMLDivElement | null>;
+  rateRef: React.RefObject<HTMLDivElement | null>;
+  limitRef: React.RefObject<HTMLDivElement | null>;
+  handleFilterChange: (category: keyof Filters, value: string) => void;
+  handleRangeChange: (value: number | number[]) => void;
+  removeFilter: (category: keyof Filters, value: string) => void;
+};
+
+const FilterSheet: React.FC<FilterSheetProps> = ({
+  showFilter,
+  setShowFilter,
+  activeFilters,
+  setActiveFilters,
+  activeTab,
+  setActiveTab,
+  keywordRef,
+  typeRef,
+  purposeRef,
+  rateRef,
+  limitRef,
+  handleFilterChange,
+  handleRangeChange,
+  removeFilter,
+}) => {
+  // Updated formatCurrency function
+  const formatCurrencyLocal = (value: number) => {
+    if (value === 0) {
+      return '5천만원 이하'; // Assuming 0 represents "5천만원 이하" as the lower bound
+    }
+    if (value === 100000000) {
+      return '1억원 초과'; // Assuming 100,000,000 represents "1억원 초과" as the upper bound
+    }
+
+    const units = ['원', '만원', '억원'];
+    const unitValues = [1, 10000, 100000000]; // 1원, 1만원, 1억원
+
+    let result = '';
+    let tempValue = value;
+
+    for (let i = units.length - 1; i >= 0; i--) {
+      const unitValue = unitValues[i];
+      const unit = units[i];
+
+      if (tempValue >= unitValue) {
+        const num = Math.floor(tempValue / unitValue);
+        result += num.toLocaleString('ko-KR') + unit;
+        tempValue %= unitValue;
+      }
+    }
+    return result || '0원'; // Return '0원' if value is 0 or less than 1 unit
+  };
+
+  return (
+    showFilter && (
+      <div className="absolute inset-0 z-[60] flex items-end justify-center bg-black bg-opacity-30">
+        <div
+          className="w-full bg-white pt-4 rounded-t-3xl shadow-xl flex flex-col"
+          style={{ maxHeight: '90vh' }}
+        >
+          <div className="px-4 overflow-y-auto no-scrollbar">
+            {/* 탭 영역 */}
+            <div className="sticky top-0 bg-white z-10border-gray-200 flex gap-2 px-2">
+              {[
+                { key: 'keyword', label: '키워드' },
+                { key: 'type', label: '사업자구분' },
+                { key: 'purpose', label: '대출용도' },
+                { key: 'rate', label: '금리구분' },
+                { key: 'limit', label: '대출한도' },
+              ].map((tab) => (
+                <button
+                  key={tab.key}
+                  className={`flex-1 py-3 text-[11px] font-semibold -mb-px border-b-2 mx-1 justify-center tracking-wide ${activeTab === tab.key ? '' : 'text-gray-700'}`}
+                  style={{
+                    borderColor:
+                      activeTab === tab.key ? colors.navy : 'transparent',
+                    color: activeTab === tab.key ? colors.navy : '#222',
+                    opacity: activeTab === tab.key ? 1 : 0.7,
+                  }}
+                  onClick={() => {
+                    setActiveTab(tab.key);
+                    const ref = {
+                      keyword: keywordRef,
+                      type: typeRef,
+                      purpose: purposeRef,
+                      rate: rateRef,
+                      limit: limitRef,
+                    }[tab.key];
+                    if (ref && ref.current) {
+                      ref.current.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start',
+                      });
+                    }
+                  }}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+            <div className="flex justify-between items-center mb-2">
+              <span className="font-bold">필터</span>
+              <button
+                className="text-sm font-bold text-gray-600"
+                onClick={() =>
+                  setActiveFilters({
+                    keywords: [],
+                    types: [],
+                    purposes: [],
+                    rates: [],
+                    limit: [0, 100000000],
+                  })
+                }
+              >
+                초기화
+              </button>
+            </div>
+            {/* Active Filters Display */}
+            <div className="w-full max-w-md px-2 mb-4 flex flex-wrap gap-2">
+              {Object.entries(activeFilters).map(
+                ([category, values]) =>
+                  category !== 'limit' &&
+                  (values as string[]).map((value) => (
+                    <div
+                      key={`${category}-${value}`}
+                      className="flex items-center gap-1 bg-navy text-white text-xs font-semibold px-2 py-1 rounded-full"
+                      style={{ backgroundColor: colors.navy }}
+                    >
+                      <span>{value}</span>
+                      <button
+                        onClick={() =>
+                          removeFilter(category as keyof Filters, value)
+                        }
+                        className="text-white ml-1"
+                      >
+                        &times;
+                      </button>
+                    </div>
+                  )),
+              )}
+            </div>
+
+            <div ref={keywordRef} className="mb-6">
+              <div className="font-bold mb-2">키워드</div>
+              <div className="flex gap-2 flex-wrap">
+                {[
+                  '#창업초기',
+                  '#제조업',
+                  '#업력무관',
+                  '#피해업체',
+                  '#수출',
+                ].map((item) => (
+                  <button
+                    key={item}
+                    onClick={() => handleFilterChange('keywords', item)}
+                    className="px-4 py-2 rounded-full text-xs"
+                    style={{
+                      backgroundColor: activeFilters.keywords.includes(item)
+                        ? colors.navy
+                        : colors.gray,
+                      color: activeFilters.keywords.includes(item)
+                        ? 'white'
+                        : '#222',
+                    }}
+                  >
+                    {item}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div ref={typeRef} className="mb-6">
+              <div className="font-bold mb-2">사업자구분</div>
+              <div className="flex gap-2 flex-wrap">
+                {[
+                  '예비창업자',
+                  '소상공인(개인)',
+                  '소상공인(법인)',
+                  '소기업',
+                ].map((item) => (
+                  <button
+                    key={item}
+                    onClick={() => handleFilterChange('types', item)}
+                    className="px-4 py-2 rounded-full text-xs"
+                    style={{
+                      backgroundColor: activeFilters.types.includes(item)
+                        ? colors.navy
+                        : colors.gray,
+                      color: activeFilters.types.includes(item)
+                        ? 'white'
+                        : '#222',
+                    }}
+                  >
+                    {item}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div ref={purposeRef} className="mb-6">
+              <div className="font-bold mb-2">대출용도</div>
+              <div className="flex gap-2 flex-wrap">
+                {['운전자금', '시설자금'].map((item) => (
+                  <button
+                    key={item}
+                    onClick={() => handleFilterChange('purposes', item)}
+                    className="px-4 py-2 rounded-full text-xs"
+                    style={{
+                      backgroundColor: activeFilters.purposes.includes(item)
+                        ? colors.navy
+                        : colors.gray,
+                      color: activeFilters.purposes.includes(item)
+                        ? 'white'
+                        : '#222',
+                    }}
+                  >
+                    {item}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div ref={rateRef} className="mb-6">
+              <div className="font-bold mb-2">금리구분</div>
+              <div className="flex gap-2 flex-wrap">
+                {['변동금리', '고정금리'].map((item) => (
+                  <button
+                    key={item}
+                    onClick={() => handleFilterChange('rates', item)}
+                    className="px-4 py-2 rounded-full text-xs"
+                    style={{
+                      backgroundColor: activeFilters.rates.includes(item)
+                        ? colors.navy
+                        : colors.gray,
+                      color: activeFilters.rates.includes(item)
+                        ? 'white'
+                        : '#222',
+                    }}
+                  >
+                    {item}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div ref={limitRef} className="mb-6">
+              <div className="font-bold mb-2">대출한도</div>
+              <div className="w-full flex items-center justify-between text-sm font-semibold mb-2">
+                <span>{formatCurrencyLocal(activeFilters.limit[0])}</span>
+                <span>{formatCurrencyLocal(activeFilters.limit[1])}</span>
+              </div>
+              <Slider
+                range
+                min={0}
+                max={100000000}
+                step={1000000}
+                value={activeFilters.limit}
+                onChange={handleRangeChange}
+                trackStyle={[{ backgroundColor: colors.navy }]}
+                handleStyle={[
+                  { backgroundColor: colors.navy, borderColor: colors.navy },
+                  { backgroundColor: colors.navy, borderColor: colors.navy },
+                ]}
+              />
+            </div>
+          </div>
+          <div className="sticky bottom-0 bg-white p-4 flex justify-between gap-2 shadow-[0_-4px_8px_rgba(0,0,0,0.05)]">
+            <button
+              className="flex-1 py-3 rounded-lg bg-gray-200 text-sm font-semibold"
+              onClick={() => setShowFilter(false)}
+            >
+              닫기
+            </button>
+            <button
+              className="flex-1 py-3 rounded-lg text-white text-sm font-semibold"
+              style={{ backgroundColor: colors.navy }}
+              onClick={() => setShowFilter(false)}
+            >
+              결과보기
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  );
+};
+
+export default FilterSheet;

--- a/src/components/support/FundCard.tsx
+++ b/src/components/support/FundCard.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { colors } from '../../styles/colors';
+
+type FundListItem = {
+  id: number;
+  name: string;
+  status: string;
+  target: string;
+  rate: string;
+  term: string;
+  limitAmount: string;
+  saved: boolean;
+};
+
+const FundCard: React.FC<{
+  item: FundListItem;
+  onDetailClick: (id: number) => void;
+  onBookmarkClick: (id: number, saved: boolean) => void;
+}> = ({ item, onDetailClick, onBookmarkClick }) => {
+  return (
+    <div
+      className="bg-white rounded-xl shadow-md p-4 flex flex-col gap-3 border border-gray-100 cursor-pointer hover:shadow-lg transition relative"
+      onClick={() => onDetailClick(item.id)}
+      style={{ borderColor: '#f0f2f5' }}
+    >
+      {/* 북마크 버튼 */}
+      <button
+        className="absolute top-4 right-4 text-2xl focus:outline-none z-10"
+        onClick={(e) => {
+          e.stopPropagation();
+          onBookmarkClick(item.id, item.saved);
+        }}
+        aria-label="북마크"
+      >
+        {item.saved ? (
+          <span className="text-yellow-400">★</span>
+        ) : (
+          <span className="text-gray-300 hover:text-yellow-400">☆</span>
+        )}
+      </button>
+
+      <div className="flex items-center gap-2">
+        <span
+          className={`px-3 py-1 text-xs font-bold rounded-full ${
+            item.status === '마감'
+              ? 'bg-gray-200 text-gray-500'
+              : 'bg-navy text-white'
+          }`}
+          style={{
+            backgroundColor:
+              item.status === '마감' ? colors.gray : colors.navy,
+          }}
+        >
+          {item.status}
+        </span>
+        <span className="text-xs font-semibold text-gray-500">대리대출</span>
+      </div>
+
+      <div className="font-bold text-lg text-gray-800 pr-8">{item.name}</div>
+    </div>
+  );
+};
+
+export default FundCard;

--- a/src/components/support/FundDetailModal.tsx
+++ b/src/components/support/FundDetailModal.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { colors } from '../../styles/colors'; // Import colors
+
+// Define FundDetail type here for clarity and type safety
+type FundDetail = {
+  id: number;
+  name: string;
+  status: string;
+  target: string;
+  rate: string;
+  term: string;
+  limitAmount: string;
+  saved: boolean;
+  purpose: string;
+  createdAt: string;
+  updatedAt?: string;
+  categoryCode: string;
+  year: number;
+};
+
+interface FundDetailModalProps {
+  open: boolean;
+  onClose: () => void;
+  fund: FundDetail | null; // Use the defined type
+}
+
+const FundDetailModal: React.FC<FundDetailModalProps> = ({
+  open,
+  onClose,
+  fund,
+}) => {
+  if (!open || !fund) return null;
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black bg-opacity-30 p-4">
+      <div className="bg-white rounded-3xl p-6 w-full max-w-md relative shadow-xl flex flex-col" style={{ maxHeight: '90vh' }}>
+        
+        <h2 className="font-bold text-2xl mb-4 text-gray-800" style={{ color: colors.navy }}>{fund.name}</h2>
+
+        <div className="flex-grow overflow-y-auto no-scrollbar pr-2">
+          <div className="mb-4 p-3 rounded-lg" style={{ backgroundColor: colors.gray }}>
+            <p className="text-sm text-gray-600 mb-1">
+              <span className="font-semibold">상태: </span>
+              <span className={`font-bold ${fund.status === '마감' ? 'text-red-500' : 'text-green-600'}`}>
+                {fund.status}
+              </span>
+            </p>
+            <p className="text-sm text-gray-600">
+              <span className="font-semibold">북마크: </span>
+              <span className="text-yellow-400">{fund.saved ? '★' : '☆'}</span>
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 mb-4">
+            <div className="bg-gray-50 p-3 rounded-lg col-span-2">
+              <p className="text-xs text-gray-500">지원대상</p>
+              <p className="font-semibold text-sm text-gray-800">{fund.target}</p>
+            </div>
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <p className="text-xs text-gray-500">대출용도</p>
+              <p className="font-semibold text-sm text-gray-800">{fund.purpose}</p>
+            </div>
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <p className="text-xs text-gray-500">대출기간</p>
+              <p className="font-semibold text-sm text-gray-800">{fund.term}</p>
+            </div>
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <p className="text-xs text-gray-500">대출한도</p>
+              <p className="font-semibold text-sm text-gray-800">{fund.limitAmount}</p>
+            </div>
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <p className="text-xs text-gray-500">금리</p>
+              <p className="font-semibold text-sm text-gray-800">{fund.rate}</p>
+            </div>
+            
+          </div>
+        </div>
+
+        <button
+          className="mt-4 py-3 rounded-lg text-white text-lg font-semibold w-full"
+          style={{ backgroundColor: colors.navy }}
+          onClick={onClose}
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FundDetailModal;

--- a/src/components/support/FundDetailModal.tsx
+++ b/src/components/support/FundDetailModal.tsx
@@ -32,7 +32,7 @@ const FundDetailModal: React.FC<FundDetailModalProps> = ({
   if (!open || !fund) return null;
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black bg-opacity-30 p-4">
-      <div className="bg-white rounded-3xl p-6 w-full max-w-md relative shadow-xl flex flex-col" style={{ maxHeight: '90vh' }}>
+      <div className="bg-white rounded-3xl p-6 w-full max-w-sm relative shadow-xl flex flex-col overflow-hidden" style={{ maxHeight: '80vh' }}>
         
         <h2 className="font-bold text-2xl mb-4 text-gray-800" style={{ color: colors.navy }}>{fund.name}</h2>
 

--- a/src/components/support/FundsList.tsx
+++ b/src/components/support/FundsList.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import FundCard from './FundCard';
+import type { FundListItem } from '../../types/support';
+
+type FundsListProps = {
+  funds: FundListItem[];
+  bookmarkFunds: FundListItem[];
+  loading: boolean;
+  bookmarkLoading: boolean;
+  isBookmarkMode: boolean;
+  onDetailClick: (id: number) => void;
+  onBookmarkClick: (id: number, saved: boolean) => void;
+};
+
+const FundsList: React.FC<FundsListProps> = ({
+  funds,
+  bookmarkFunds,
+  loading,
+  bookmarkLoading,
+  isBookmarkMode,
+  onDetailClick,
+  onBookmarkClick,
+}) => {
+  if (isBookmarkMode) {
+    return (
+      <div className="flex flex-col gap-3">
+        {bookmarkLoading && (
+          <div className="text-center text-gray-400 py-8">. . .</div>
+        )}
+        {!bookmarkLoading && bookmarkFunds.length === 0 && (
+          <div className="text-center text-gray-400 py-8">
+            북마크한 지원금이 없습니다.
+          </div>
+        )}
+        {bookmarkFunds.map((item) => (
+          <FundCard
+            key={item.id}
+            item={item}
+            onDetailClick={onDetailClick}
+            onBookmarkClick={onBookmarkClick}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {loading && (
+        <div className="text-center text-gray-400 py-8">. . .</div>
+      )}
+      {!loading && funds.length === 0 && (
+        <div className="text-center text-gray-400 py-8">
+          지원금 정보가 없습니다.
+        </div>
+      )}
+      {funds.map((item) => (
+        <FundCard
+          key={item.id}
+          item={item}
+          onDetailClick={onDetailClick}
+          onBookmarkClick={onBookmarkClick}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default FundsList;

--- a/src/components/support/KakaoMap.tsx
+++ b/src/components/support/KakaoMap.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useRef } from 'react';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+type KakaoMapProps = {
+  businessLocation?: { lat: number; lng: number };
+  centerLocation?: { lat: number; lng: number };
+  center?: any; // 센터 정보
+  onCenterMarkerClick?: (center: any) => void; // 센터 마커 클릭 콜백
+  className?: string;
+};
+
+const KakaoMap: React.FC<KakaoMapProps> = ({
+  businessLocation,
+  centerLocation,
+  center,
+  onCenterMarkerClick,
+  className = 'w-full h-48',
+}) => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstance = useRef<any>(null);
+  const businessMarker = useRef<any>(null);
+  const centerMarker = useRef<any>(null);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+
+    const initMap = () => {
+      const { kakao } = window;
+      if (!kakao || !kakao.maps) {
+        console.error('카카오맵 API가 로드되지 않음');
+        return;
+      }
+
+      // 기본 좌표 (센터가 있으면 센터, 없으면 기본값)
+      const defaultLat = centerLocation?.lat || 37.5665;
+      const defaultLng = centerLocation?.lng || 126.978;
+
+      const options = {
+        center: new kakao.maps.LatLng(defaultLat, defaultLng),
+        level: 8,
+      };
+
+      const map = new kakao.maps.Map(mapRef.current, options);
+      mapInstance.current = map;
+
+      // 사업장 마커 추가
+      if (businessLocation) {
+        const businessPosition = new kakao.maps.LatLng(
+          businessLocation.lat,
+          businessLocation.lng,
+        );
+
+        const businessMarkerImage = new kakao.maps.MarkerImage(
+          'data:image/svg+xml;charset=utf-8,' +
+            encodeURIComponent(`
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="16" cy="16" r="14" fill="#ff6b6b" stroke="white" stroke-width="3"/>
+              <rect x="10" y="8" width="12" height="16" rx="1" fill="white"/>
+              <rect x="12" y="10" width="2" height="2" fill="#ff6b6b"/>
+              <rect x="15" y="10" width="2" height="2" fill="#ff6b6b"/>
+              <rect x="18" y="10" width="2" height="2" fill="#ff6b6b"/>
+              <rect x="12" y="13" width="2" height="2" fill="#ff6b6b"/>
+              <rect x="15" y="13" width="2" height="2" fill="#ff6b6b"/>
+              <rect x="18" y="13" width="2" height="2" fill="#ff6b6b"/>
+              <rect x="13" y="19" width="6" height="3" fill="#ff6b6b"/>
+            </svg>
+          `),
+          new kakao.maps.Size(32, 32),
+          { offset: new kakao.maps.Point(16, 16) },
+        );
+
+        businessMarker.current = new kakao.maps.Marker({
+          position: businessPosition,
+          image: businessMarkerImage,
+        });
+        businessMarker.current.setMap(map);
+      }
+
+      // 센터 마커 추가
+      if (centerLocation) {
+        const centerPosition = new kakao.maps.LatLng(
+          centerLocation.lat,
+          centerLocation.lng,
+        );
+
+        const centerMarkerImage = new kakao.maps.MarkerImage(
+          'data:image/svg+xml;charset=utf-8,' +
+            encodeURIComponent(`
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M16 4C11.6 4 8 7.6 8 12c0 6 8 16 8 16s8-10 8-16c0-4.4-3.6-8-8-8z" fill="#4CAF50" stroke="white" stroke-width="2"/>
+              <circle cx="16" cy="12" r="4" fill="white"/>
+              <circle cx="16" cy="12" r="2" fill="#4CAF50"/>
+            </svg>
+          `),
+          new kakao.maps.Size(32, 32),
+          { offset: new kakao.maps.Point(16, 28) },
+        );
+
+        centerMarker.current = new kakao.maps.Marker({
+          position: centerPosition,
+          image: centerMarkerImage,
+        });
+        centerMarker.current.setMap(map);
+
+        // 센터 마커 클릭 이벤트 추가
+        if (onCenterMarkerClick && center) {
+          kakao.maps.event.addListener(centerMarker.current, 'click', () => {
+            onCenterMarkerClick(center);
+          });
+        }
+
+        // 지도 중심을 센터로 이동
+        map.setCenter(centerPosition);
+      }
+
+      // 두 마커가 모두 있을 때 적절한 줌 레벨로 조정
+      if (businessLocation && centerLocation) {
+        const bounds = new kakao.maps.LatLngBounds();
+        bounds.extend(
+          new kakao.maps.LatLng(businessLocation.lat, businessLocation.lng),
+        );
+        bounds.extend(
+          new kakao.maps.LatLng(centerLocation.lat, centerLocation.lng),
+        );
+        map.setBounds(bounds, 50);
+      }
+    };
+
+    if (window.kakao && window.kakao.maps) {
+      initMap();
+    } else {
+      // 이미 동일한 스크립트가 로딩중인지 확인
+      const existingScript = document.querySelector(
+        `script[src*="dapi.kakao.com"]`,
+      );
+      if (existingScript) {
+        return;
+      }
+
+      // 스크립트가 아직 로드되지 않았다면 이벤트 리스너로 대기
+      const script = document.createElement('script');
+      const apiKey = import.meta.env.VITE_KAKAO_MAP_KEY;
+      script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${apiKey}&autoload=false`;
+      script.onload = () => {
+        window.kakao.maps.load(initMap);
+      };
+      script.onerror = (error) => {
+        console.error('카카오맵 스크립트 로드 실패:', error);
+        // 로드 실패 시 fallback 화면 표시
+        const fallback = document.getElementById('map-fallback');
+        if (fallback) {
+          fallback.style.display = 'flex';
+          fallback.innerHTML =
+            '지도를 불러올 수 없습니다. API 키를 확인해주세요.';
+        }
+      };
+      document.head.appendChild(script);
+    }
+
+    return () => {
+      // 컴포넌트 언마운트 시 마커 정리
+      if (businessMarker.current) {
+        businessMarker.current.setMap(null);
+      }
+      if (centerMarker.current) {
+        centerMarker.current.setMap(null);
+      }
+    };
+  }, [businessLocation, centerLocation]);
+
+  return (
+    <div className={className}>
+      <div ref={mapRef} className="w-full h-full" />
+      {/* 카카오맵 로딩 실패 시 fallback */}
+      <div
+        className="flex items-center justify-center text-gray-500 text-sm absolute inset-0 bg-gray-100 rounded-xl"
+        style={{ display: 'none' }}
+        id="map-fallback"
+      >
+        지도를 불러오는 중입니다...
+      </div>
+    </div>
+  );
+};
+
+export default KakaoMap;

--- a/src/components/support/MapView.tsx
+++ b/src/components/support/MapView.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import KakaoMap from './KakaoMap';
+import SupportCenterCard from './SupportCenterCard';
+import type { SupportCenter, NearestCentersData } from '../../types/support';
+
+type MapViewProps = {
+  mapLoading: boolean;
+  allCenters: SupportCenter[];
+  selectedCenter: SupportCenter | null;
+  nearestData: NearestCentersData | null;
+  businessAddress: string | null;
+  onCenterSelect: (center: SupportCenter) => void;
+  onCenterMarkerClick: (center: SupportCenter) => Promise<void>;
+};
+
+const MapView: React.FC<MapViewProps> = ({
+  mapLoading,
+  allCenters,
+  selectedCenter,
+  nearestData,
+  businessAddress,
+  onCenterSelect,
+  onCenterMarkerClick,
+}) => {
+  if (mapLoading) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="text-center text-gray-400 py-8">. . .</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* 다른 센터 보기 드롭다운 */}
+      {allCenters.length > 0 && (
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            다른 센터 보기
+          </label>
+          <select
+            className="w-full p-2 border border-gray-300 rounded-lg text-sm"
+            value={selectedCenter?.id || ''}
+            onChange={(e) => {
+              const centerId = parseInt(e.target.value);
+              const center = allCenters.find(c => c.id === centerId);
+              if (center) onCenterSelect(center);
+            }}
+          >
+            {nearestData && nearestData.nearestCenters.length > 0 && (
+              <option value={nearestData.nearestCenters[0].center.id}>
+                🎯 {nearestData.nearestCenters[0].center.name} (가장 가까운 센터)
+              </option>
+            )}
+            {allCenters
+              .filter(center => 
+                !nearestData || 
+                !nearestData.nearestCenters.find(nc => nc.center.id === center.id)
+              )
+              .map(center => (
+                <option key={center.id} value={center.id}>
+                  {center.name}
+                </option>
+              ))
+            }
+          </select>
+        </div>
+      )}
+
+      {/* 카카오맵 */}
+      <KakaoMap
+        businessLocation={nearestData ? {
+          lat: nearestData.businessLat,
+          lng: nearestData.businessLng
+        } : undefined}
+        centerLocation={selectedCenter ? {
+          lat: selectedCenter.lat,
+          lng: selectedCenter.lng
+        } : undefined}
+        center={selectedCenter}
+        onCenterMarkerClick={onCenterMarkerClick}
+        className="w-full h-48 rounded-xl"
+      />
+
+      {/* 주소 미등록 안내 */}
+      {!businessAddress && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-sm">
+          <div className="font-medium text-yellow-800 mb-1">
+            ⚠️ 사업장 주소 미등록
+          </div>
+          <div className="text-yellow-700">
+            정확한 가까운 센터 조회를 위해 사업장 주소를 등록해주세요.
+          </div>
+        </div>
+      )}
+
+      {/* 센터 상세 정보 카드 */}
+      {selectedCenter && (
+        <SupportCenterCard
+          center={selectedCenter}
+          distance={
+            nearestData 
+              ? nearestData.nearestCenters.find(nc => nc.center.id === selectedCenter.id)?.distanceKm
+              : undefined
+          }
+          businessAddress={businessAddress || undefined}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MapView;

--- a/src/components/support/PlaceDetailModal.tsx
+++ b/src/components/support/PlaceDetailModal.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+
+type PlaceDetailModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  place: {
+    id: string;
+    name: string;
+    address: string;
+    lat: number;
+    lng: number;
+  } | null;
+};
+
+const PlaceDetailModal: React.FC<PlaceDetailModalProps> = ({
+  isOpen,
+  onClose,
+  place,
+}) => {
+  const [iframeError, setIframeError] = useState(false);
+
+  if (!isOpen || !place) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-5">
+      <div className="bg-white rounded-2xl w-full max-w-sm h-[70vh] flex flex-col">
+        {/* 헤더 - 축소 */}
+        <div className="flex justify-between items-center p-3 border-b flex-shrink-0">
+          <h3 className="text-base font-bold text-gray-800 truncate">
+            {place.name}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 text-lg ml-2"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* 카카오맵 상세보기 iframe */}
+        <div className="flex-1 overflow-hidden">
+          {!iframeError ? (
+            <iframe
+              src={`https://place.map.kakao.com/${place.id}`}
+              className="w-full h-full border-0"
+              title="카카오맵 상세보기"
+              onError={() => setIframeError(true)}
+              sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-top-navigation"
+            />
+          ) : (
+            <div className="w-full h-full flex flex-col items-center justify-center bg-gray-50 text-gray-500">
+              <div className="text-xl mb-4">🗺️</div>
+              <div className="text-sm mb-4">상세보기를 불러올 수 없습니다</div>
+              <div className="flex gap-2">
+                <a
+                  href={`https://place.map.kakao.com/${place.id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-yellow-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-yellow-600 transition-colors"
+                >
+                  🗺️ 카카오맵에서 보기
+                </a>
+                <a
+                  href={`https://map.kakao.com/link/to/${encodeURIComponent(place.name)},${place.lat},${place.lng}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-blue-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-blue-600 transition-colors"
+                >
+                  🚗 길찾기
+                </a>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlaceDetailModal;

--- a/src/components/support/SearchForm.tsx
+++ b/src/components/support/SearchForm.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+type SearchFormProps = {
+  search: string;
+  searching: boolean;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: (e: React.FormEvent) => void;
+};
+
+const SearchForm: React.FC<SearchFormProps> = ({
+  search,
+  searching,
+  onSearchChange,
+  onSubmit,
+}) => {
+  return (
+    <form
+      className="flex items-center gap-2 mb-4 w-full max-w-md px-2"
+      onSubmit={onSubmit}
+    >
+      <i className="fas fa-search text-gray-400"></i>
+      <input
+        type="text"
+        value={search}
+        onChange={onSearchChange}
+        placeholder="지원금정보를 검색해보세요"
+        className="flex-1 px-3 py-2 rounded bg-gray-100 text-sm outline-none"
+      />
+      <button
+        type="submit"
+        className="px-2 py-2 rounded bg-navy text-white text-xs font-semibold"
+        disabled={searching}
+      >
+        검색
+      </button>
+    </form>
+  );
+};
+
+export default SearchForm;

--- a/src/components/support/SupportCenterCard.tsx
+++ b/src/components/support/SupportCenterCard.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+type SupportCenter = {
+  id: number;
+  name: string;
+  jurisdiction: string;
+  address: string;
+  phone: string;
+  fax: string;
+  lat: number;
+  lng: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SupportCenterCardProps = {
+  center: SupportCenter;
+  distance?: number;
+  businessAddress?: string;
+};
+
+const SupportCenterCard: React.FC<SupportCenterCardProps> = ({
+  center,
+  distance,
+  businessAddress,
+}) => {
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-5">
+      {/* 사업장 주소 태그 */}
+      {businessAddress && (
+        <div className="inline-flex items-center gap-1 bg-blue-50 text-blue-700 px-3 py-1 rounded-full text-xs font-medium mb-4">
+          <span>🏢</span>
+          <span>등록 사업장: {businessAddress}</span>
+        </div>
+      )}
+      
+      {/* 센터명과 거리 */}
+      <div className="mb-4 flex justify-between items-center">
+        <h3 className="font-bold text-xl text-gray-800 leading-tight flex-1">
+          {center.name}
+        </h3>
+        {distance && (
+          <div className="inline-flex bg-green-50 text-green-700 px-2 py-1 rounded-lg text-xs font-semibold ml-2">
+            {distance}km
+          </div>
+        )}
+      </div>
+      
+      {/* 정보 카드들 */}
+      <div className="space-y-3 mb-4">
+        {/* 관할 구역 */}
+        <div className="bg-gray-50 rounded-lg p-3">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-blue-500">📍</span>
+            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">관할구역</span>
+          </div>
+          <div className="text-sm text-gray-700 font-medium">
+            {center.jurisdiction}
+          </div>
+        </div>
+        
+        {/* 주소 */}
+        <div className="bg-gray-50 rounded-lg p-3">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-green-500">🏠</span>
+            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">주소</span>
+          </div>
+          <div className="text-sm text-gray-700">
+            {center.address}
+          </div>
+        </div>
+        
+        {/* 연락처 */}
+        <div className="bg-gray-50 rounded-lg p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-purple-500">📞</span>
+            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">연락처</span>
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-gray-700 font-medium">
+              전화: {center.phone}
+            </div>
+            {center.fax && (
+              <div className="text-sm text-gray-600">
+                팩스: {center.fax}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+    </div>
+  );
+};
+
+export default SupportCenterCard;

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,47 @@ body::-webkit-scrollbar {
   --blue-color: #7dbcff;
   --mid-color: #2b2d42;
 }
+
+.range-navy {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  background: #d3d3d3;
+  outline: none;
+  opacity: 0.7;
+  -webkit-transition: .2s;
+  transition: opacity .2s;
+  border-radius: 5px;
+}
+
+.range-navy:hover {
+  opacity: 1;
+}
+
+.range-navy::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  background: #25437B;
+  cursor: pointer;
+  border-radius: 50%;
+}
+
+.range-navy::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  background: #25437B;
+  cursor: pointer;
+  border-radius: 50%;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -1,7 +1,370 @@
-const Support = () => (
-  <div className="flex items-center justify-center h-96 text-2xl font-bold">
-    공공지원금 더미 페이지
-  </div>
-);
+import React, { useState, useEffect } from 'react';
+
+import FilterSheet from '../components/support/FilterSheet';
+import FundDetailModal from '../components/support/FundDetailModal';
+import FundCard from '../components/support/FundCard';
+import {
+  getFundsList,
+  getFundDetail,
+  toggleBookmark,
+  getBookmarkedFunds,
+  searchFunds,
+} from '../api/fundApi';
+
+// Types
+type Filters = {
+  keywords: string[];
+  types: string[];
+  purposes: string[];
+  rates: string[];
+  limit: [number, number];
+};
+
+type FundListItem = {
+  id: number;
+  name: string;
+  status: string;
+  target: string;
+  rate: string;
+  term: string;
+  limitAmount: string;
+  saved: boolean;
+};
+
+type FundDetail = FundListItem & {
+  purpose: string;
+  createdAt: string;
+  updatedAt?: string;
+  categoryCode: string;
+  year: number;
+};
+
+const Support: React.FC = () => {
+  // State
+  const [funds, setFunds] = useState<FundListItem[]>([]);
+  const [search, setSearch] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [selectedFund, setSelectedFund] = useState<FundDetail | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [showMap, setShowMap] = useState(false);
+  const [showFilter, setShowFilter] = useState(false);
+  const [activeTab, setActiveTab] = useState('keyword');
+  const [showBookmarkList, setShowBookmarkList] = useState(false);
+  const [bookmarkFunds, setBookmarkFunds] = useState<FundListItem[]>([]);
+  const [bookmarkLoading, setBookmarkLoading] = useState(false);
+  const [activeFilters, setActiveFilters] = useState<Filters>({
+    keywords: [],
+    types: [],
+    purposes: [],
+    rates: [],
+    limit: [0, 100000000],
+  });
+
+  // Refs for filter sheet
+  const keywordRef = React.useRef<HTMLDivElement>(null);
+  const typeRef = React.useRef<HTMLDivElement>(null);
+  const purposeRef = React.useRef<HTMLDivElement>(null);
+  const rateRef = React.useRef<HTMLDivElement>(null);
+  const limitRef = React.useRef<HTMLDivElement>(null);
+
+  // Event Handlers
+  const handleSearchChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearch(value);
+
+    if (value.trim() === '') {
+      setSearching(true);
+      try {
+        const res = await getFundsList();
+        if (res.status === 200 && Array.isArray(res.data)) {
+          setFunds(res.data);
+        } else {
+          setFunds([]);
+        }
+      } finally {
+        setSearching(false);
+      }
+    }
+  };
+
+  const handleFilterChange = (category: keyof Filters, value: string) => {
+    setActiveFilters((prev) => {
+      if (category === 'limit') return prev;
+      const arr = prev[category] as string[];
+      if (arr.includes(value)) {
+        return { ...prev, [category]: arr.filter((v) => v !== value) };
+      } else {
+        return { ...prev, [category]: [...arr, value] };
+      }
+    });
+  };
+
+  const handleRangeChange = (value: number | number[]) => {
+    if (Array.isArray(value) && value.length === 2) {
+      setActiveFilters((prev) => ({ ...prev, limit: [value[0], value[1]] }));
+    }
+  };
+
+  const removeFilter = (category: keyof Filters, value: string) => {
+    setActiveFilters((prev) => {
+      if (category === 'limit') return prev;
+      return {
+        ...prev,
+        [category]: (prev[category] as string[]).filter((v) => v !== value),
+      };
+    });
+  };
+
+  
+
+  const openDetail = async (id: number) => {
+    setLoading(true);
+    try {
+      const res = await getFundDetail(id);
+      if (res.status === 200 && res.data) {
+        setSelectedFund(res.data);
+        setShowDetail(true);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBookmark = async (id: number, saved: boolean) => {
+    await toggleBookmark(id, saved);
+
+    // 리스트 갱신
+    getFundsList().then((res) => {
+      if (res.status === 200 && Array.isArray(res.data)) {
+        setFunds(res.data);
+      }
+    });
+
+    // 상세 모달 내 북마크도 갱신
+    if (selectedFund && selectedFund.id === id) {
+      const detail = await getFundDetail(id);
+      if (detail.status === 200 && detail.data) setSelectedFund(detail.data);
+    }
+  };
+
+  const handleBookmarkListToggle = async () => {
+    setShowBookmarkList((prev) => !prev);
+
+    if (!showBookmarkList) {
+      setBookmarkLoading(true);
+      try {
+        const res = await getBookmarkedFunds();
+        if (res.status === 200 && Array.isArray(res.data)) {
+          setBookmarkFunds(
+            res.data.map((fund: any) => ({ ...fund, saved: true })),
+          );
+        } else {
+          setBookmarkFunds([]);
+        }
+      } finally {
+        setBookmarkLoading(false);
+      }
+    }
+  };
+
+  const handleMapToggle = () => {
+    setShowMap((prev) => !prev);
+    window.scrollTo(0, 0);
+  };
+
+  // Effects
+  useEffect(() => {
+    setLoading(true);
+    getFundsList()
+      .then((res) => {
+        if (res.status === 200 && Array.isArray(res.data)) {
+          setFunds(res.data);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center py-4">
+      {/* 검색 폼 */}
+      <form
+        className="flex items-center gap-2 mb-4 w-full max-w-md px-2"
+        onSubmit={async (e) => {
+          e.preventDefault();
+          if (!search.trim()) return;
+          setSearching(true);
+          try {
+            const data = await searchFunds(search);
+            setFunds(Array.isArray(data.data) ? data.data : []);
+          } finally {
+            setSearching(false);
+          }
+        }}
+      >
+        <i className="fas fa-search text-gray-400"></i>
+        <input
+          type="text"
+          value={search}
+          onChange={handleSearchChange}
+          placeholder="지원금정보를 검색해보세요"
+          className="flex-1 px-3 py-2 rounded bg-gray-100 text-sm outline-none"
+        />
+        <button
+          type="submit"
+          className="px-2 py-2 rounded bg-navy text-white text-xs font-semibold"
+          disabled={searching}
+        >
+          검색
+        </button>
+      </form>
+
+      {/* 필터 버튼들 */}
+      <div className="flex gap-2 mb-4 w-full max-w-md px-2">
+        <button
+          className="px-3 py-2 rounded bg-gray-200 text-xs font-semibold"
+          onClick={() => setShowFilter(true)}
+        >
+          :: 필터
+        </button>
+        <button
+          className="px-3 py-2 rounded bg-gray-200 text-xs font-semibold"
+          onClick={handleMapToggle}
+        >
+          내센터
+        </button>
+        <button
+          className="px-3 py-2 rounded bg-gray-200 text-xs font-semibold"
+          onClick={async () => {
+            setLoading(true);
+            try {
+              const res = await getFundsList();
+              if (res.status === 200 && Array.isArray(res.data)) {
+                const filteredFunds = res.data.filter((fund: FundListItem) => fund.status === '접수중');
+                setFunds(filteredFunds);
+              } else {
+                setFunds([]);
+              }
+            } finally {
+              setLoading(false);
+            }
+          }}
+        >
+          접수중
+        </button>
+        <button
+          className="px-3 py-2 rounded bg-gray-200 text-xl font-semibold flex items-center justify-center"
+          aria-label="북마크"
+          onClick={handleBookmarkListToggle}
+        >
+          <span className="text-yellow-400">★</span>
+        </button>
+      </div>
+
+      {/* 필터 시트 */}
+      {showFilter && (
+        <FilterSheet
+          showFilter={showFilter}
+          setShowFilter={setShowFilter}
+          activeFilters={activeFilters}
+          setActiveFilters={setActiveFilters}
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          keywordRef={keywordRef}
+          typeRef={typeRef}
+          purposeRef={purposeRef}
+          rateRef={rateRef}
+          limitRef={limitRef}
+          handleFilterChange={handleFilterChange}
+          handleRangeChange={handleRangeChange}
+          removeFilter={removeFilter}
+          
+        />
+      )}
+
+      {/* 메인 컨텐츠 */}
+      <div
+        key={showMap ? 'map' : showBookmarkList ? 'bookmark' : 'list'}
+        className="w-full max-w-md px-2"
+      >
+        {showBookmarkList ? (
+          // 북마크 리스트
+          <div className="flex flex-col gap-3">
+            {bookmarkLoading && (
+              <div className="text-center text-gray-400 py-8">. . .</div>
+            )}
+            {!bookmarkLoading && bookmarkFunds.length === 0 && (
+              <div className="text-center text-gray-400 py-8">
+                북마크한 지원금이 없습니다.
+              </div>
+            )}
+            {bookmarkFunds.map((item) => (
+              <FundCard
+                key={item.id}
+                item={item}
+                onDetailClick={openDetail}
+                onBookmarkClick={handleBookmark}
+              />
+            ))}
+          </div>
+        ) : showMap ? (
+          // 지도 뷰
+          <div className="flex flex-col gap-4">
+            <div className="w-full h-48 bg-gray-200 rounded-xl flex items-center justify-center text-gray-500 text-sm mb-2">
+              <span>센터 위치 지도 (구현 예정)</span>
+            </div>
+            <div className="bg-white rounded-xl shadow p-4 border border-gray-100">
+              <div className="font-bold mb-1">
+                인천 미추홀구 소상공인지원센터
+              </div>
+              <div className="text-xs text-gray-600 mb-1">
+                인천 미추홀구 석정로 229 IT타워 6층
+              </div>
+              <div className="text-xs text-gray-600 mb-1">
+                운영시간: 평일 10:00~오후 6:00
+              </div>
+              <div className="text-xs text-gray-600">전화: 032-715-4047</div>
+              <a
+                href="https://inisupport.or.kr/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-600 underline mt-1 inline-block"
+              >
+                홈페이지 바로가기
+              </a>
+            </div>
+          </div>
+        ) : (
+          // 일반 펀드 리스트
+          <div className="flex flex-col gap-3">
+            {loading && (
+              <div className="text-center text-gray-400 py-8">. . .</div>
+            )}
+            {!loading && funds.length === 0 && (
+              <div className="text-center text-gray-400 py-8">
+                지원금 정보가 없습니다.
+              </div>
+            )}
+            {funds.map((item) => (
+              <FundCard
+                key={item.id}
+                item={item}
+                onDetailClick={openDetail}
+                onBookmarkClick={handleBookmark}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 상세 모달 */}
+      <FundDetailModal
+        open={showDetail}
+        onClose={() => setShowDetail(false)}
+        fund={selectedFund}
+      />
+    </div>
+  );
+};
 
 export default Support;

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -3,7 +3,11 @@ import { colors } from '../styles/colors';
 
 import FilterSheet from '../components/support/FilterSheet';
 import FundDetailModal from '../components/support/FundDetailModal';
-import FundCard from '../components/support/FundCard';
+import PlaceDetailModal from '../components/support/PlaceDetailModal';
+import SearchForm from '../components/support/SearchForm';
+import FilterButtons from '../components/support/FilterButtons';
+import MapView from '../components/support/MapView';
+import FundsList from '../components/support/FundsList';
 import {
   getFundsList,
   getFundDetail,
@@ -11,34 +15,22 @@ import {
   getBookmarkedFunds,
   searchFunds,
 } from '../api/fundApi';
+import {
+  getAllSupportCenters,
+  getNearestSupportCenters,
+  getBusinessAddress,
+} from '../api/supportCenterApi';
+import type {
+  SupportCenter,
+  NearestCenterResponse,
+  NearestCentersData,
+  Filters,
+  FundListItem,
+  FundDetail,
+  MainFilter,
+  PlaceDetail,
+} from '../types/support';
 
-// Types
-type Filters = {
-  keywords: string[];
-  types: string[];
-  purposes: string[];
-  rates: string[];
-  limit: [number, number];
-};
-
-type FundListItem = {
-  id: number;
-  name: string;
-  status: string;
-  target: string;
-  rate: string;
-  term: string;
-  limitAmount: string;
-  saved: boolean;
-};
-
-type FundDetail = FundListItem & {
-  purpose: string;
-  createdAt: string;
-  updatedAt?: string;
-  categoryCode: string;
-  year: number;
-};
 
 const Support: React.FC = () => {
   // State
@@ -48,7 +40,7 @@ const Support: React.FC = () => {
   const [selectedFund, setSelectedFund] = useState<FundDetail | null>(null);
   const [showDetail, setShowDetail] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [activeMainFilter, setActiveMainFilter] = useState<'none' | 'filter' | 'map' | 'receiving' | 'bookmark'>('none');
+  const [activeMainFilter, setActiveMainFilter] = useState<MainFilter>('none');
   const [activeTab, setActiveTab] = useState('keyword');
   const [activeFilters, setActiveFilters] = useState<Filters>({
     keywords: [],
@@ -59,6 +51,17 @@ const Support: React.FC = () => {
   });
   const [bookmarkFunds, setBookmarkFunds] = useState<FundListItem[]>([]);
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
+
+  // 지원센터 관련 상태
+  const [businessAddress, setBusinessAddress] = useState<string | null>(null);
+  const [allCenters, setAllCenters] = useState<SupportCenter[]>([]);
+  const [selectedCenter, setSelectedCenter] = useState<SupportCenter | null>(null);
+  const [nearestData, setNearestData] = useState<NearestCentersData | null>(null);
+  const [mapLoading, setMapLoading] = useState(false);
+  
+  // 장소 상세 모달 상태
+  const [showModal, setShowModal] = useState(false);
+  const [modalPlace, setModalPlace] = useState<PlaceDetail | null>(null);
 
   // Refs for filter sheet
   const keywordRef = React.useRef<HTMLDivElement>(null);
@@ -145,6 +148,174 @@ const Support: React.FC = () => {
     }
   };
 
+  // 지원센터 관련 이벤트 핸들러
+  const handleCenterSelect = (center: SupportCenter) => {
+    setSelectedCenter(center);
+  };
+
+  // 카카오 장소 검색 함수
+  const searchKakaoPlace = async (centerName: string): Promise<PlaceDetail | null> => {
+    try {
+      const apiKey = import.meta.env.VITE_KAKAO_REST_KEY;
+      if (!apiKey) {
+        console.error('카카오 REST API 키가 없습니다.');
+        return null;
+      }
+
+      // 조직명을 제거하고 "소상공인 [센터명] 센터" 형식으로 검색
+      const centerNameOnly = centerName.replace(/^소상공인시장진흥공단\s*/, '');
+      const searchQuery = `소상공인 ${centerNameOnly} 센터`;
+
+      const response = await fetch(
+        `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(searchQuery)}`,
+        {
+          headers: {
+            'Authorization': `KakaoAK ${apiKey}`
+          }
+        }
+      );
+
+      if (!response.ok) {
+        console.error('카카오 API 호출 실패:', response.status);
+        return null;
+      }
+
+      const data = await response.json();
+      
+      if (data.documents && data.documents.length > 0) {
+        const place = data.documents[0];
+        return {
+          id: place.id,
+          name: place.place_name,
+          address: place.address_name,
+          lat: parseFloat(place.y),
+          lng: parseFloat(place.x)
+        };
+      }
+      
+      return null;
+    } catch (error) {
+      console.error('카카오 장소 검색 오류:', error);
+      return null;
+    }
+  };
+
+  // 필터 버튼 핸들러들
+  const handleReceivingFilter = async () => {
+    if (activeMainFilter === 'receiving') {
+      setActiveMainFilter('none');
+      setLoading(true);
+      try {
+        const res = await getFundsList();
+        if (res.status === 200 && Array.isArray(res.data)) {
+          setFunds(res.data);
+        } else {
+          setFunds([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setActiveMainFilter('receiving');
+      setLoading(true);
+      try {
+        const res = await getFundsList();
+        if (res.status === 200 && Array.isArray(res.data)) {
+          const filteredFunds = res.data.filter((fund: FundListItem) => fund.status === '접수중');
+          setFunds(filteredFunds);
+        } else {
+          setFunds([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  const handleBookmarkFilter = async () => {
+    if (activeMainFilter === 'bookmark') {
+      setActiveMainFilter('none');
+      setLoading(true);
+      try {
+        const res = await getFundsList();
+        if (res.status === 200 && Array.isArray(res.data)) {
+          setFunds(res.data);
+        } else {
+          setFunds([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setActiveMainFilter('bookmark');
+      setBookmarkLoading(true);
+      try {
+        const res = await getBookmarkedFunds();
+        if (res.status === 200 && Array.isArray(res.data)) {
+          setBookmarkFunds(
+            res.data.map((fund: any) => ({ ...fund, saved: true })),
+          );
+        } else {
+          setBookmarkFunds([]);
+        }
+      } finally {
+        setBookmarkLoading(false);
+      }
+    }
+  };
+
+  // 검색 폼 핸들러
+  const handleSearchSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!search.trim()) return;
+    setSearching(true);
+    try {
+      const data = await searchFunds(search);
+      setFunds(Array.isArray(data.data) ? data.data : []);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  // 초기 데이터 로드
+  useEffect(() => {
+    const loadCenterData = async () => {
+      if (activeMainFilter === 'map') {
+        setMapLoading(true);
+        try {
+          // 1. 전체 센터 목록 로드
+          const centersRes = await getAllSupportCenters();
+          if (centersRes.status === 200) {
+            setAllCenters(centersRes.data);
+          }
+
+          // 2. 사업장 주소 조회
+          const addressRes = await getBusinessAddress();
+          if (addressRes.status === 200 && addressRes.address) {
+            setBusinessAddress(addressRes.address);
+            
+            // 3. 가까운 센터 조회
+            const nearestRes = await getNearestSupportCenters(addressRes.address, 1);
+            if (nearestRes.status === 200 && nearestRes.data) {
+              setNearestData(nearestRes.data);
+              setSelectedCenter(nearestRes.data.nearestCenters[0]?.center || null);
+            }
+          } else {
+            setBusinessAddress(null);
+            // 사업장 주소가 없으면 첫 번째 센터를 기본으로 선택
+            if (centersRes.data.length > 0) {
+              setSelectedCenter(centersRes.data[0]);
+            }
+          }
+        } finally {
+          setMapLoading(false);
+        }
+      }
+    };
+
+    loadCenterData();
+  }, [activeMainFilter]);
+
   // Effects
   useEffect(() => {
     const fetchFunds = async () => {
@@ -171,126 +342,23 @@ const Support: React.FC = () => {
   }, [activeMainFilter]);
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col items-center py-4">
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center py-4 no-scrollbar overflow-y-auto">
       {/* 검색 폼 */}
-      <form
-        className="flex items-center gap-2 mb-4 w-full max-w-md px-2"
-        onSubmit={async (e) => {
-          e.preventDefault();
-          if (!search.trim()) return;
-          setSearching(true);
-          try {
-            const data = await searchFunds(search);
-            setFunds(Array.isArray(data.data) ? data.data : []);
-          } finally {
-            setSearching(false);
-          }
-        }}
-      >
-        <i className="fas fa-search text-gray-400"></i>
-        <input
-          type="text"
-          value={search}
-          onChange={handleSearchChange}
-          placeholder="지원금정보를 검색해보세요"
-          className="flex-1 px-3 py-2 rounded bg-gray-100 text-sm outline-none"
-        />
-        <button
-          type="submit"
-          className="px-2 py-2 rounded bg-navy text-white text-xs font-semibold"
-          disabled={searching}
-        >
-          검색
-        </button>
-      </form>
+      <SearchForm
+        search={search}
+        searching={searching}
+        onSearchChange={handleSearchChange}
+        onSubmit={handleSearchSubmit}
+      />
 
       {/* 필터 버튼들 */}
-      <div className="flex gap-2 mb-4 w-full max-w-md px-2">
-        <button
-          className={`px-3 py-2 rounded text-xs font-semibold ${activeMainFilter === 'filter' ? 'bg-navy text-white' : 'bg-gray-200'}`}
-          onClick={() => setActiveMainFilter(activeMainFilter === 'filter' ? 'none' : 'filter')}
-        >
-          :: 필터
-        </button>
-        <button
-          className={`px-3 py-2 rounded text-xs font-semibold ${activeMainFilter === 'map' ? 'bg-navy text-white' : 'bg-gray-200'}`}
-          onClick={() => setActiveMainFilter(activeMainFilter === 'map' ? 'none' : 'map')}
-        >
-          내센터
-        </button>
-        <button
-          className={`px-3 py-2 rounded text-xs font-semibold ${activeMainFilter === 'receiving' ? 'bg-navy text-white' : 'bg-gray-200'}`}
-          onClick={async () => {
-            if (activeMainFilter === 'receiving') {
-              setActiveMainFilter('none');
-              setLoading(true);
-              try {
-                const res = await getFundsList();
-                if (res.status === 200 && Array.isArray(res.data)) {
-                  setFunds(res.data);
-                } else {
-                  setFunds([]);
-                }
-              } finally {
-                setLoading(false);
-              }
-            } else {
-              setActiveMainFilter('receiving');
-              setLoading(true);
-              try {
-                const res = await getFundsList();
-                if (res.status === 200 && Array.isArray(res.data)) {
-                  const filteredFunds = res.data.filter((fund: FundListItem) => fund.status === '접수중');
-                  setFunds(filteredFunds);
-                } else {
-                  setFunds([]);
-                }
-              } finally {
-                setLoading(false);
-              }
-            }
-          }}
-        >
-          접수중
-        </button>
-        <button
-          className={`px-3 py-2 rounded text-xl font-semibold flex items-center justify-center ${activeMainFilter === 'bookmark' ? 'bg-navy text-white' : 'bg-gray-200'}`}
-          aria-label="북마크"
-          onClick={async () => {
-            if (activeMainFilter === 'bookmark') {
-              setActiveMainFilter('none');
-              setLoading(true);
-              try {
-                const res = await getFundsList();
-                if (res.status === 200 && Array.isArray(res.data)) {
-                  setFunds(res.data);
-                } else {
-                  setFunds([]);
-                }
-              } finally {
-                setLoading(false);
-              }
-            } else {
-              setActiveMainFilter('bookmark');
-              setBookmarkLoading(true);
-              try {
-                const res = await getBookmarkedFunds();
-                if (res.status === 200 && Array.isArray(res.data)) {
-                  setBookmarkFunds(
-                    res.data.map((fund: any) => ({ ...fund, saved: true })),
-                  );
-                } else {
-                  setBookmarkFunds([]);
-                }
-              } finally {
-                setBookmarkLoading(false);
-              }
-            }
-          }}
-        >
-          <span className="text-yellow-400">★</span>
-        </button>
-      </div>
+      <FilterButtons
+        activeMainFilter={activeMainFilter}
+        onFilterClick={() => setActiveMainFilter(activeMainFilter === 'filter' ? 'none' : 'filter')}
+        onMapClick={() => setActiveMainFilter(activeMainFilter === 'map' ? 'none' : 'map')}
+        onReceivingClick={handleReceivingFilter}
+        onBookmarkClick={handleBookmarkFilter}
+      />
 
       {/* 필터 시트 */}
       {activeMainFilter === 'filter' && (
@@ -317,73 +385,32 @@ const Support: React.FC = () => {
         key={activeMainFilter}
         className="w-full max-w-md px-2"
       >
-        {activeMainFilter === 'bookmark' ? (
-          // 북마크 리스트
-          <div className="flex flex-col gap-3">
-            {bookmarkLoading && (
-              <div className="text-center text-gray-400 py-8">. . .</div>
-            )}
-            {!bookmarkLoading && bookmarkFunds.length === 0 && (
-              <div className="text-center text-gray-400 py-8">
-                북마크한 지원금이 없습니다.
-              </div>
-            )}
-            {bookmarkFunds.map((item) => (
-              <FundCard
-                key={item.id}
-                item={item}
-                onDetailClick={openDetail}
-                onBookmarkClick={handleBookmark}
-              />
-            ))}
-          </div>
-        ) : activeMainFilter === 'map' ? (
-          // 지도 뷰
-          <div className="flex flex-col gap-4">
-            <div className="w-full h-48 bg-gray-200 rounded-xl flex items-center justify-center text-gray-500 text-sm mb-2">
-              <span>센터 위치 지도 (구현 예정)</span>
-            </div>
-            <div className="bg-white rounded-xl shadow p-4 border border-gray-100">
-              <div className="font-bold mb-1">
-                인천 미추홀구 소상공인지원센터
-              </div>
-              <div className="text-xs text-gray-600 mb-1">
-                인천 미추홀구 석정로 229 IT타워 6층
-              </div>
-              <div className="text-xs text-gray-600 mb-1">
-                운영시간: 평일 10:00~오후 6:00
-              </div>
-              <div className="text-xs text-gray-600">전화: 032-715-4047</div>
-              <a
-                href="https://inisupport.or.kr/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 underline mt-1 inline-block"
-              >
-                홈페이지 바로가기
-              </a>
-            </div>
-          </div>
+        {activeMainFilter === 'map' ? (
+          <MapView
+            mapLoading={mapLoading}
+            allCenters={allCenters}
+            selectedCenter={selectedCenter}
+            nearestData={nearestData}
+            businessAddress={businessAddress}
+            onCenterSelect={handleCenterSelect}
+            onCenterMarkerClick={async (center) => {
+              const place = await searchKakaoPlace(center.name);
+              if (place) {
+                setModalPlace(place);
+                setShowModal(true);
+              }
+            }}
+          />
         ) : (
-          // 일반 펀드 리스트 (or when activeMainFilter is 'receiving' or 'none')
-          <div className="flex flex-col gap-3">
-            {loading && (
-              <div className="text-center text-gray-400 py-8">. . .</div>
-            )}
-            {!loading && funds.length === 0 && (
-              <div className="text-center text-gray-400 py-8">
-                지원금 정보가 없습니다.
-              </div>
-            )}
-            {funds.map((item) => (
-              <FundCard
-                key={item.id}
-                item={item}
-                onDetailClick={openDetail}
-                onBookmarkClick={handleBookmark}
-              />
-            ))}
-          </div>
+          <FundsList
+            funds={funds}
+            bookmarkFunds={bookmarkFunds}
+            loading={loading}
+            bookmarkLoading={bookmarkLoading}
+            isBookmarkMode={activeMainFilter === 'bookmark'}
+            onDetailClick={openDetail}
+            onBookmarkClick={handleBookmark}
+          />
         )}
       </div>
 
@@ -392,6 +419,13 @@ const Support: React.FC = () => {
         open={showDetail}
         onClose={() => setShowDetail(false)}
         fund={selectedFund}
+      />
+      
+      {/* 장소 상세 모달 */}
+      <PlaceDetailModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        place={modalPlace}
       />
     </div>
   );

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -1,0 +1,62 @@
+export type SupportCenter = {
+  id: number;
+  name: string;
+  jurisdiction: string;
+  address: string;
+  phone: string;
+  fax: string;
+  lat: number;
+  lng: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type NearestCenterResponse = {
+  center: SupportCenter;
+  distanceKm: number;
+  rank: number;
+};
+
+export type NearestCentersData = {
+  searchedAddress: string;
+  businessLat: number;
+  businessLng: number;
+  nearestCenters: NearestCenterResponse[];
+};
+
+export type Filters = {
+  keywords: string[];
+  types: string[];
+  purposes: string[];
+  rates: string[];
+  limit: [number, number];
+};
+
+export type FundListItem = {
+  id: number;
+  name: string;
+  status: string;
+  target: string;
+  rate: string;
+  term: string;
+  limitAmount: string;
+  saved: boolean;
+};
+
+export type FundDetail = FundListItem & {
+  purpose: string;
+  createdAt: string;
+  updatedAt?: string;
+  categoryCode: string;
+  year: number;
+};
+
+export type MainFilter = 'none' | 'filter' | 'map' | 'receiving' | 'bookmark';
+
+export type PlaceDetail = {
+  id: string;
+  name: string;
+  address: string;
+  lat: number;
+  lng: number;
+};


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
- 정책지원금 프론트 화면 구현
## 📖 작업 내용 
- 지원금 메인 페이지
  - 정책지원금 목록보기
  - 정책지원금 상세보기 모달
  - 필터링 모달
  - 접수중인 지원금만 보기
  - 북마크한 지원금만 보기
  - 지원금 정보 검색
 - 내센터보기
   - 카카오맵 지도로 사업장과, 센터 지도에 마커 표시
   - 사업장 주소기준 가장 가까운 센터 반환
   - 해당 센터 정보, 거리 반환
   - 지도 위 센터 마커를 누르면, 카카오맵 상세페이지로 연결되는 모달창
   - 드롭다운을 통해 다른 센터도 확인할 수 있음(내 사업장위치는 고정)
 
### 추가사항
- kakao map api 사용으로 notion > 키 관련 문서에 프론트 .env 추가했습니다

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항
- 필터링 로직에 대해서 얘기해봐야할 거 같아서 아직 로직은 구현하지 않았습니다
- 사업장 주소를 받아오는 API 가 필요합니다.

## 🔗 관련 이슈
- closes #3 

### 지원금
<img width="461" height="833" alt="스크린샷 2025-09-06 오후 3 42 11" src="https://github.com/user-attachments/assets/50c3a874-e091-4fb1-aef1-e4e6cf7b1d62" />
<img width="496" height="844" alt="스크린샷 2025-09-06 오후 3 42 15" src="https://github.com/user-attachments/assets/eaf903af-8dda-4e94-a98f-addd64a8b678" />

### 센터
<img width="466" height="854" alt="스크린샷 2025-09-06 오후 3 42 24" src="https://github.com/user-attachments/assets/efafd2b7-7183-4501-abc9-b4e33ee22715" />


<img width="568" height="864" alt="스크린샷 2025-09-06 오후 3 54 22" src="https://github.com/user-attachments/assets/a3014e19-667d-467f-b3aa-d5bfa70c74b0" />

