### PR TITLE
feat: UI 홈/시뮬 결과 리스트/상세 1차 반영 (Mock)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import Header from './components/common/Header';
 import Navbar from './components/common/Navbar';
-import Home from './pages/Home';
+import Home from './home/pages/Home';
 import Guide from './pages/Guide';
 import Support from './pages/Support';
 import Community from './community/index.tsx';
@@ -9,29 +9,20 @@ import MyPage from './pages/MyPage';
 import Login from '@/pages/auth/Login';
 import Signup from '@/pages/auth/Signup';
 import FindIdPw from '@/pages/auth/FindIdPw';
+import SimulationList from './simulation/pages/SimulationList';
+import SimulationDetail from './simulation/pages/SimulationDetail';
 
 function AppChrome() {
     const { pathname } = useLocation();
-
-    // 검색 입력 화면(/community/search)에서만 헤더 감춤
-    const isSearchScreen =
-        pathname === '/community/search' || pathname === '/community/search/';
-
-    const paddingTop = isSearchScreen ? 0 : 56; // 헤더 높이
-    const paddingBottom = 60;                    // 네브바 높이
+    const isSearchScreen = pathname === '/community/search' || pathname === '/community/search/';
+    const hideHeader = isSearchScreen || pathname === '/';           // 홈에서는 헤더 감춤
+    const paddingTop = hideHeader ? 0 : 56;
+    const paddingBottom = 60;
 
     return (
         <>
-            {!isSearchScreen && <Header />}
-
-            <main
-                style={{
-                    flex: 1,
-                    overflowY: 'auto',
-                    paddingTop,
-                    paddingBottom,
-                }}
-            >
+            {!hideHeader && <Header />}
+            <main style={{ flex: 1, overflowY: 'auto', paddingTop, paddingBottom }}>
                 <Routes>
                     <Route path="/" element={<Home />} />
                     <Route path="/guide" element={<Guide />} />
@@ -41,9 +32,10 @@ function AppChrome() {
                     <Route path="/auth/login" element={<Login />} />
                     <Route path="/auth/signup" element={<Signup />} />
                     <Route path="/auth/find" element={<FindIdPw />} />
+                    <Route path="/simulation" element={<SimulationList />} />
+                    <Route path="/simulation/:id" element={<SimulationDetail />} />
                 </Routes>
             </main>
-
             <Navbar />
         </>
     );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -21,6 +21,11 @@ const routeTitle = (path: string) => {
 
   // 기본값
   if (path.startsWith('/community')) return '커뮤니티';
+
+  // 시뮬레이션 결과
+  if (path === '/simulation') return '시뮬레이션 내역';
+  if (path.match(/^\/simulation\/\d+/)) return '시뮬레이션 내역';
+
   return '';
 };
 

--- a/src/home/components/EmptySimulationCard.tsx
+++ b/src/home/components/EmptySimulationCard.tsx
@@ -1,0 +1,32 @@
+import { colors } from '@/styles/colors';
+import { useNavigate } from 'react-router-dom';
+import { Megaphone, ChevronRight } from 'lucide-react';
+
+export default function EmptySimulationCard() {
+    const nav = useNavigate();
+    return (
+        <button
+            onClick={() => nav('/simulation')}
+            className="w-full text-left rounded-3xl p-5 bg-white border shadow-[0_10px_30px_rgba(37,67,123,0.06)] relative overflow-hidden"
+            style={{ borderColor: colors.paleBlue }}
+        >
+            <div className="flex items-start gap-3">
+                <div className="shrink-0 w-10 h-10 rounded-2xl grid place-items-center"
+                     style={{ background: colors.paleBlue, color: colors.navy }}>
+                    <Megaphone className="w-5 h-5" />
+                </div>
+                <div className="flex-1">
+                    <div className="text-[15px] font-extrabold mb-1" style={{ color: colors.navy }}>
+                        대출가이드 현황 및 바로가기
+                    </div>
+                    <div className="text-[12px] text-gray-600 mb-3">
+                        진행 중인 시뮬레이션이 없어요. 새 시뮬을 시작해 보세요!
+                    </div>
+                    <div className="w-full h-3 rounded-full bg-gray-100" />
+                    <div className="mt-2 text-[11px] text-gray-500">진행률 0% · 상태 없음</div>
+                </div>
+                <ChevronRight className="w-5 h-5 text-gray-400 mt-1" />
+            </div>
+        </button>
+    );
+}

--- a/src/home/components/GuideStatusCard.tsx
+++ b/src/home/components/GuideStatusCard.tsx
@@ -1,0 +1,48 @@
+import { colors } from '@/styles/colors';
+import { useNavigate } from 'react-router-dom';
+import type { SimulationListItem } from '@/simulation/types';
+import { Megaphone, ChevronRight } from 'lucide-react';
+
+export default function GuideStatusCard({ active }: { active: SimulationListItem }) {
+    const nav = useNavigate();
+    const pct = active.progressPct ?? 0;
+    const bar = pct >= 100 ? colors.blue : pct >= 75 ? '#F59E0B' : colors.navy;
+
+    return (
+        <button
+            onClick={() => nav(`/simulation/${active.id}`)}
+            className="w-full text-left rounded-3xl p-5 bg-white border shadow-[0_10px_30px_rgba(37,67,123,0.06)] relative overflow-hidden"
+            style={{ borderColor: colors.paleBlue }}
+        >
+            {/* 장식 원형 그라데이션 */}
+            <div
+                className="absolute -right-6 -top-10 w-40 h-40 rounded-full opacity-20 pointer-events-none"
+                style={{ background: `radial-gradient(closest-side, ${colors.lightBlue}, transparent)` }}
+            />
+            <div className="flex items-start gap-3">
+                <div className="shrink-0 w-10 h-10 rounded-2xl grid place-items-center"
+                     style={{ background: colors.paleBlue, color: colors.navy }}>
+                    <Megaphone className="w-5 h-5" />
+                </div>
+                <div className="flex-1">
+                    <div className="text-[15px] font-extrabold mb-1" style={{ color: colors.navy }}>
+                        대출가이드 현황 및 바로가기
+                    </div>
+                    <div className="text-[12px] text-gray-600 mb-3">
+                        {`${active.title} · 시작 ${active.startProbability}% → 예상 ${active.expectedProbability}%`}
+                    </div>
+
+                    <div className="w-full h-3 rounded-full bg-gray-200">
+                        <div className="h-3 rounded-full transition-all" style={{ width: `${pct}%`, background: bar }} />
+                    </div>
+
+                    <div className="mt-2 text-[11px] text-gray-500">
+                        진행률 {pct}% · 상태 {active.status === 'COMPLETED' ? '완료' : active.status === 'IN_PROGRESS' ? '진행중' : '대기'}
+                    </div>
+                </div>
+
+                <ChevronRight className="w-5 h-5 text-gray-400 mt-1" />
+            </div>
+        </button>
+    );
+}

--- a/src/home/components/GuideStatusCarousel.tsx
+++ b/src/home/components/GuideStatusCarousel.tsx
@@ -1,0 +1,38 @@
+import { useRef, useState, useEffect } from 'react';
+import type { SimulationListItem } from '@/simulation/types';
+import GuideStatusSlideCard from './GuideStatusSlideCard';
+import { colors } from '@/styles/colors';
+
+export default function GuideStatusCarousel({ items }: { items: SimulationListItem[] }) {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const [idx, setIdx] = useState(0);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        const onScroll = () => {
+            const i = Math.round(el.scrollLeft / el.clientWidth);
+            setIdx(i);
+        };
+        el.addEventListener('scroll', onScroll, { passive: true });
+        return () => el.removeEventListener('scroll', onScroll);
+    }, []);
+
+    return (
+        <div>
+            <div ref={ref} className="flex overflow-x-auto no-scrollbar snap-x snap-mandatory">
+                {items.map((it) => <GuideStatusSlideCard key={it.id} item={it} />)}
+            </div>
+            {/* dots */}
+            <div className="flex items-center justify-center gap-2 mt-3">
+                {items.slice(0, 4).map((_, i) => (
+                    <div
+                        key={i}
+                        className="w-2 h-2 rounded-full"
+                        style={{ background: i === idx ? colors.navy : colors.paleBlue }}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/home/components/GuideStatusSlideCard.tsx
+++ b/src/home/components/GuideStatusSlideCard.tsx
@@ -1,0 +1,46 @@
+import { colors } from '@/styles/colors';
+import { useNavigate } from 'react-router-dom';
+import type { SimulationListItem } from '@/simulation/types';
+import { Megaphone } from 'lucide-react';
+
+const STATUS_BAR = {
+    COMPLETED: '#10B981',   // green
+    IN_PROGRESS: '#F59E0B', // orange
+    FAILED: '#EF4444',      // red
+    PENDING: colors.navy,
+} as const;
+
+export default function GuideStatusSlideCard({ item }: { item: SimulationListItem }) {
+    const nav = useNavigate();
+    const bar = STATUS_BAR[item.status as keyof typeof STATUS_BAR] ?? colors.navy;
+
+    return (
+        <div
+            onClick={() => nav(`/simulation/${item.id}`)}
+            className="snap-center shrink-0 w-[330px] rounded-3xl p-5 bg-white border shadow-[0_14px_40px_rgba(37,67,123,0.08)] mr-4 cursor-pointer relative overflow-hidden"
+            style={{ borderColor: colors.paleBlue }}
+        >
+            <div className="absolute -right-10 -top-14 w-52 h-52 rounded-full opacity-20 pointer-events-none"
+                 style={{ background: `radial-gradient(closest-side, ${colors.lightBlue}, transparent)` }} />
+            <div className="flex items-start gap-3">
+                <div className="shrink-0 w-12 h-12 rounded-2xl grid place-items-center"
+                     style={{ background: colors.paleBlue, color: colors.navy }}>
+                    <Megaphone className="w-6 h-6" />
+                </div>
+                <div className="flex-1">
+                    <div className="text-base font-extrabold mb-1" style={{ color: colors.navy }}>
+                        대출가이드 현황 및 바로가기
+                    </div>
+                    <div className="text-[12px] text-gray-600 mb-3">
+                        {`${item.title} · 시작 ${item.startProbability}% → 예상 ${item.expectedProbability}%`}
+                    </div>
+
+                    <div className="w-full h-3 rounded-full bg-gray-200">
+                        <div className="h-3 rounded-full" style={{ width: `${item.progressPct}%`, background: bar }} />
+                    </div>
+                    <div className="mt-2 text-[11px] text-gray-500">진행률 {item.progressPct}%</div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/home/components/HomeGreeting.tsx
+++ b/src/home/components/HomeGreeting.tsx
@@ -1,0 +1,23 @@
+import { colors } from '@/styles/colors';
+import { useDisplayName } from '../utils/user';
+import { Sparkles } from 'lucide-react';
+
+export default function HomeGreeting() {
+    const name = useDisplayName();
+    return (
+        <div className="mb-3">
+            <div className="flex items-center gap-2 mb-1">
+        <span
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[11px] font-semibold"
+            style={{ background: colors.paleBlue, color: colors.navy, border: `1px solid ${colors.lightBlue}` }}
+        >
+          <Sparkles className="w-3.5 h-3.5" />
+          가이드온
+        </span>
+            </div>
+            <div className="text-[22px] leading-7 font-extrabold" style={{ color: '#111827' }}>
+                {name}님 현재 시뮬 상황
+            </div>
+        </div>
+    );
+}

--- a/src/home/components/HomeHero.tsx
+++ b/src/home/components/HomeHero.tsx
@@ -1,0 +1,38 @@
+import { colors } from '@/styles/colors';
+import { Bell, User, Search } from 'lucide-react';
+import { useDisplayName } from '../utils/user';
+
+export default function HomeHero() {
+    const name = useDisplayName();
+
+    return (
+        <div
+            className="rounded-b-3xl pb-5 text-white"
+            style={{
+                background: `linear-gradient(180deg, ${colors.blue} 0%, ${colors.navy} 100%)`,
+            }}
+        >
+            <div className="px-4 pt-4 flex items-center justify-between">
+                <div className="text-xl font-extrabold tracking-wide">가이드온</div>
+                <div className="flex gap-3 opacity-90">
+                    <Bell className="w-5 h-5" />
+                    <User className="w-5 h-5" />
+                </div>
+            </div>
+
+            <div className="px-4 mt-1 text-[13px] opacity-90">
+                {name}님, 무엇을 도와드릴까요?
+            </div>
+
+            <div className="px-4 mt-3">
+                <div className="flex items-center gap-2 bg-white/95 rounded-full px-3 py-2 shadow-sm">
+                    <Search className="w-4 h-4 text-gray-500" />
+                    <input
+                        className="bg-transparent outline-none text-sm flex-1 placeholder-gray-400"
+                        placeholder="대출/지원 정보를 검색해보세요"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/home/components/HomeStatsRow.tsx
+++ b/src/home/components/HomeStatsRow.tsx
@@ -1,0 +1,22 @@
+import { colors } from '@/styles/colors';
+
+export default function HomeStatsRow({
+                                         joined, inProgress, avgExpected,
+                                     }: { joined: number; inProgress: number; avgExpected: number; }) {
+    const Cell = ({ label, value }: { label: string; value: string }) => (
+        <div
+            className="flex-1 rounded-2xl bg-white p-3 text-left"
+            style={{ border: `2px solid ${colors.paleBlue}` }}
+        >
+            <div className="text-[11px] text-gray-500 mb-1">{label}</div>
+            <div className="text-lg font-extrabold" style={{ color: colors.navy }}>{value}</div>
+        </div>
+    );
+    return (
+        <div className="grid grid-cols-3 gap-2 mb-8">
+            <Cell label="참여한 개수" value={`${joined}건`} />
+            <Cell label="현재 진행 중인" value={`${inProgress}건`} />
+            <Cell label="예상 확률" value={`${avgExpected}%`} />
+        </div>
+    );
+}

--- a/src/home/components/RichLinkCard.tsx
+++ b/src/home/components/RichLinkCard.tsx
@@ -1,0 +1,32 @@
+import { colors } from '@/styles/colors';
+import type {ReactNode} from 'react';
+
+export default function RichLinkCard({
+                                         title, subtitle, onClick, icon,
+                                     }: {
+    title: string;
+    subtitle: string;
+    onClick: () => void;
+    icon: ReactNode;
+}) {
+    return (
+        <button
+            onClick={onClick}
+            className="w-full rounded-3xl text-left p-4 bg-white border shadow-[0_10px_30px_rgba(37,67,123,0.06)] relative overflow-hidden"
+            style={{ borderColor: colors.paleBlue }}
+        >
+            <div className="absolute -right-6 -bottom-10 w-32 h-32 rounded-full opacity-20"
+                 style={{ background: `radial-gradient(closest-side, ${colors.lightBlue}, transparent)` }} />
+            <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-2xl grid place-items-center"
+                     style={{ background: colors.paleBlue, color: colors.navy }}>
+                    {icon}
+                </div>
+                <div>
+                    <div className="text-sm font-semibold" style={{ color: colors.navy }}>{title}</div>
+                    <div className="text-[12px] text-gray-600">{subtitle}</div>
+                </div>
+            </div>
+        </button>
+    );
+}

--- a/src/home/components/SectionTitleRow.tsx
+++ b/src/home/components/SectionTitleRow.tsx
@@ -1,0 +1,28 @@
+import { colors } from '@/styles/colors';
+
+export default function SectionTitleRow({
+                                            title,
+                                            actionLabel,
+                                            onAction,
+                                        }: {
+    title: string;
+    actionLabel?: string;
+    onAction?: () => void;
+}) {
+    return (
+        <div className="mb-2 flex items-center justify-between">
+            <div className="text-sm font-semibold" style={{ color: colors.navy }}>
+                {title}
+            </div>
+            {actionLabel && onAction && (
+                <button
+                    className="text-xs px-2 py-1 rounded-full"
+                    onClick={onAction}
+                    style={{ background: colors.paleBlue, color: colors.navy }}
+                >
+                    {actionLabel}
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/home/hooks/useHomeMock.ts
+++ b/src/home/hooks/useHomeMock.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { MOCK_ACTIVE_LIST, MOCK_SUMMARY } from '../utils/mock';
+import type { SimulationListItem } from '@/simulation/types';
+
+export function useHomeMock() {
+    const [list, setList] = useState<SimulationListItem[]>([]);
+    const [summary, setSummary] = useState(MOCK_SUMMARY);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const t = setTimeout(() => {
+            setList(MOCK_ACTIVE_LIST);
+            setSummary(MOCK_SUMMARY);
+            setLoading(false);
+        }, 300);
+        return () => clearTimeout(t);
+    }, []);
+
+    // 가장 최근/완료건을 active로 보여주고 싶다면 첫번째로 취급
+    const active = list[0] ?? null;
+    return { active, list, summary, loading };
+}

--- a/src/home/layouts/HomeLayout.tsx
+++ b/src/home/layouts/HomeLayout.tsx
@@ -1,0 +1,30 @@
+import type {ReactNode} from 'react';
+
+/**
+ * 홈 공통 레이아웃
+ * - 375~420px 모바일 프레임 폭 정렬
+ * - App에서 Header/BottomNav padding을 이미 주므로 여기선 내부 여백만 관리
+ */
+export default function HomeLayout({
+                                       children,
+                                       footerSpace = true,
+                                   }: {
+    children: ReactNode;
+    /** 네브바 높이만큼 하단 여백 유지 (기본 true) */
+    footerSpace?: boolean;
+}) {
+    return (
+        <div
+            className="mx-auto w-full"
+            style={{
+                maxWidth: 420,
+                paddingLeft: 16,
+                paddingRight: 16,
+                paddingTop: 8,
+                paddingBottom: footerSpace ? 96 : 0, // 네브바(+여유)
+            }}
+        >
+            {children}
+        </div>
+    );
+}

--- a/src/home/pages/Home.tsx
+++ b/src/home/pages/Home.tsx
@@ -1,0 +1,72 @@
+import HomeLayout from '../layouts/HomeLayout';
+import HomeHero from '../components/HomeHero';
+import HomeGreeting from '../components/HomeGreeting';
+import HomeStatsRow from '../components/HomeStatsRow';
+import SectionTitleRow from '../components/SectionTitleRow';
+import GuideStatusCarousel from '../components/GuideStatusCarousel';
+import RichLinkCard from '../components/RichLinkCard';
+import { useHomeMock } from '../hooks/useHomeMock';
+import { useNavigate } from 'react-router-dom';
+import { HandHeart, Users, MessageCircle } from 'lucide-react';
+
+export default function Home() {
+    const { list, summary, loading } = useHomeMock();
+    const nav = useNavigate();
+
+    return (
+        <div className="max-w-[420px] mx-auto pb-24">
+            {/* 히어로(브랜드+검색바) */}
+            <HomeHero />
+
+            <HomeLayout>
+                {/* 상단 브랜드 배지 + 인사 */}
+                <HomeGreeting />
+
+                {/* 대형 캐러셀 + 도트 */}
+                <div className="mb-6">
+                    <GuideStatusCarousel items={list.slice(0, 4)} />
+                </div>
+
+                {/* 시뮬 내역 통계 */}
+                <SectionTitleRow title="시뮬 내역" actionLabel="전체 보기" onAction={() => nav('/simulation')} />
+                {loading ? (
+                    <div className="rounded-2xl bg-gray-100 h-24 animate-pulse mb-6" />
+                ) : (
+                    <HomeStatsRow
+                        joined={summary.joinedCount}
+                        inProgress={summary.inProgressCount}
+                        avgExpected={summary.avgExpectedPct}
+                    />
+                )}
+
+                {/* 추천 */}
+                <SectionTitleRow title="추천" />
+                <div className="space-y-3 mb-4">
+                    <RichLinkCard
+                        title="공공지원금 추천"
+                        subtitle="사업 유형과 매칭되는 지원금 보기"
+                        onClick={() => nav('/support')}
+                        icon={<HandHeart className="w-5 h-5" />}
+                    />
+                </div>
+
+                {/* 커뮤니티 */}
+                <SectionTitleRow title="커뮤니티" />
+                <div className="space-y-3">
+                    <RichLinkCard
+                        title="커뮤니티 · 동종 승인 사례"
+                        subtitle="유사 업종의 실제 승인 이야기"
+                        onClick={() => nav('/community')}
+                        icon={<Users className="w-5 h-5" />}
+                    />
+                    <RichLinkCard
+                        title="자유게시판 살펴보기"
+                        subtitle="승인 꿀팁/정보 공유"
+                        onClick={() => nav('/community')}
+                        icon={<MessageCircle className="w-5 h-5" />}
+                    />
+                </div>
+            </HomeLayout>
+        </div>
+    );
+}

--- a/src/home/utils/mock.ts
+++ b/src/home/utils/mock.ts
@@ -1,0 +1,50 @@
+import type { SimulationListItem } from '@/simulation/types';
+
+export const MOCK_ACTIVE_LIST: SimulationListItem[] = [
+    {
+        id: 101,
+        title: '2024.10.25 시뮬레이션',
+        startedAt: '2024-10-25T10:00:00Z',
+        expectedProbability: 85,
+        startProbability: 50,
+        progressPct: 100,
+        status: 'COMPLETED',
+        tags: ['#신용등급보완', '#매출증대'],
+    },
+    {
+        id: 95,
+        title: '2024.10.20 시뮬레이션',
+        startedAt: '2024-10-20T11:30:00Z',
+        expectedProbability: 70,
+        startProbability: 40,
+        progressPct: 75,
+        status: 'IN_PROGRESS',
+        tags: ['#서류보완', '#사업계획서'],
+    },
+    {
+        id: 90,
+        title: '2024.10.12 시뮬레이션',
+        startedAt: '2024-10-12T08:45:00Z',
+        expectedProbability: 62,
+        startProbability: 35,
+        progressPct: 45,
+        status: 'IN_PROGRESS',
+        tags: ['#현금흐름', '#매출예측'],
+    },
+    {
+        id: 77,
+        title: '2024.10.01 시뮬레이션',
+        startedAt: '2024-10-01T09:10:00Z',
+        expectedProbability: 0,
+        startProbability: 0,
+        progressPct: 0,
+        status: 'FAILED',
+        tags: ['#검토중단'],
+    },
+];
+
+export const MOCK_SUMMARY = {
+    joinedCount: 6,
+    inProgressCount: 2,
+    avgExpectedPct: 78,
+};

--- a/src/home/utils/user.ts
+++ b/src/home/utils/user.ts
@@ -1,0 +1,18 @@
+// src/home/utils/user.ts
+import { useMemo } from 'react';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+/** 로그인 사용자 이름(없으면 '방문자') */
+export function useDisplayName(): string {
+    const user = useAuthStore((s) => s.user);
+    return useMemo(() => {
+        const nm = user?.name?.trim?.();
+        return nm && nm.length > 0 ? nm : '방문자';
+    }, [user?.name]);
+}
+
+/** 로그인 여부 플래그 (단순히 이름 존재로 판정) */
+export function useIsLoggedIn(): boolean {
+    const user = useAuthStore((s) => s.user);
+    return !!(user?.name && user.name.trim().length > 0);
+}

--- a/src/simulation/components/DonutGauge.tsx
+++ b/src/simulation/components/DonutGauge.tsx
@@ -1,0 +1,35 @@
+import { colors } from '@/styles/colors.ts';
+
+export default function DonutGauge({
+                                       value, size = 140, thickness = 12, color = colors.navy, label = '현재 승인 확률',
+                                   }: {
+    value: number; size?: number; thickness?: number; color?: string; label?: string;
+}) {
+    const v = Math.max(0, Math.min(100, Math.round(value)));
+    const r = (size - thickness) / 2;
+    const c = 2 * Math.PI * r;
+    const dash = (v / 100) * c;
+
+    return (
+        <div className="relative" style={{ width: size, height: size }}>
+            <svg width={size} height={size}>
+                <circle cx={size / 2} cy={size / 2} r={r} stroke={colors.paleBlue} strokeWidth={thickness} fill="none" />
+                <circle
+                    cx={size / 2}
+                    cy={size / 2}
+                    r={r}
+                    stroke={color}
+                    strokeWidth={thickness}
+                    fill="none"
+                    strokeDasharray={`${dash} ${c}`}
+                    strokeLinecap="round"
+                    transform={`rotate(-90 ${size / 2} ${size / 2})`}
+                />
+            </svg>
+            <div className="absolute inset-0 grid place-items-center">
+                <div className="text-3xl font-extrabold" style={{ color }}>{v}%</div>
+                <div className="text-[11px] text-gray-500 -mt-2">{label}</div>
+            </div>
+        </div>
+    );
+}

--- a/src/simulation/components/ImprovementCard.tsx
+++ b/src/simulation/components/ImprovementCard.tsx
@@ -1,0 +1,22 @@
+import { colors } from '@/styles/colors';
+import type { ImprovementSuggestion } from '../types';
+
+export default function ImprovementCard({ s }: { s: ImprovementSuggestion }) {
+    return (
+        <div className="p-4 rounded-2xl shadow-sm bg-white border" style={{ borderColor: colors.paleBlue }}>
+            <div className="text-sm font-semibold mb-1" style={{ color: colors.navy }}>
+                {s.targetMetricName}
+            </div>
+            <p className="text-xs text-gray-600 mb-2">{s.rationale}</p>
+            <div className="flex items-center justify-between text-sm">
+                <div className="text-gray-700">
+                    현재: <b>{s.currentValue ?? '-'}</b> → 제안: <b>{s.suggestedValue ?? '-'}</b>
+                </div>
+                <div className="text-right">
+                    <div className="text-xs text-gray-500">예상 상승</div>
+                    <div className="text-base font-bold" style={{ color: colors.blue }}>+{s.expectedProbabilityDelta}%p</div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/simulation/components/LabeledStepper.tsx
+++ b/src/simulation/components/LabeledStepper.tsx
@@ -1,0 +1,39 @@
+import { colors } from '@/styles/colors.ts';
+import type { SimulationStepCode, SimulationStatus } from '../types';
+
+const LABEL: Record<SimulationStepCode, string> = {
+    DOCUMENT_CHECK: '서류 검증',
+    CREDIT_CHECK: '신용도 확인',
+    BUSINESS_PLAN: '사업계획서 평가',
+    FINAL_REVIEW: '결과 확인',
+};
+
+function circleStyle(status: SimulationStatus) {
+    if (status === 'COMPLETED') return { bg: colors.blue, fg: '#fff', ring: colors.blue };
+    if (status === 'IN_PROGRESS') return { bg: colors.navy, fg: '#fff', ring: colors.navy };
+    if (status === 'FAILED') return { bg: '#EF4444', fg: '#fff', ring: '#EF4444' };
+    return { bg: '#E5E7EB', fg: '#111827', ring: '#E5E7EB' };
+}
+
+export default function LabeledStepper({
+                                           steps,
+                                       }: { steps: Array<{ stepCode: SimulationStepCode; status: SimulationStatus }>; }) {
+    return (
+        <div className="w-full flex items-start justify-between gap-2 px-3 py-3">
+            {steps.map((s, i) => {
+                const st = circleStyle(s.status);
+                return (
+                    <div key={s.stepCode} className="flex flex-col items-center flex-1 text-center">
+                        <div className="text-[11px] mb-1 text-gray-700">{LABEL[s.stepCode]}</div>
+                        <div
+                            className="w-8 h-8 rounded-full grid place-items-center text-xs font-bold"
+                            style={{ background: st.bg, color: st.fg, boxShadow: `0 0 0 2px ${st.ring}` }}
+                        >
+                            {i + 1}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/simulation/components/ListFilterBar.tsx
+++ b/src/simulation/components/ListFilterBar.tsx
@@ -1,0 +1,60 @@
+import { colors } from '@/styles/colors';
+
+type Status = 'ALL' | 'COMPLETED' | 'IN_PROGRESS' | 'FAILED' | 'PENDING';
+type Sort = 'LATEST' | 'OLDEST';
+
+export default function ListFilterBar({
+                                          status, setStatus, sort, setSort,
+                                      }: {
+    status: Status; setStatus: (s: Status) => void;
+    sort: Sort; setSort: (s: Sort) => void;
+}) {
+    const chip = (key: Status, label: string) => {
+        const active = status === key;
+        return (
+            <button
+                key={key}
+                onClick={() => setStatus(key)}
+                className="px-3 py-1 rounded-full text-xs font-semibold border"
+                style={{
+                    background: active ? colors.paleBlue : '#fff',
+                    color: active ? colors.navy : '#111827',
+                    borderColor: colors.paleBlue,
+                }}
+            >
+                {label}
+            </button>
+        );
+    };
+
+    return (
+        <div className="mb-3 flex items-center justify-between">
+            <div className="flex gap-6">
+                <div className="flex gap-1">{['ALL','COMPLETED','IN_PROGRESS','FAILED'].map((s) =>
+                    chip(s as Status, s === 'ALL' ? '전체' : s === 'COMPLETED' ? '완료' : s === 'IN_PROGRESS' ? '진행중' : '중단'))}
+                </div>
+            </div>
+
+            <div className="flex items-center text-xs gap-1">
+                <button
+                    onClick={() => setSort('LATEST')}
+                    className="px-2 py-1 rounded-full border"
+                    style={{
+                        background: sort === 'LATEST' ? colors.paleBlue : '#fff',
+                        color: sort === 'LATEST' ? colors.navy : '#111827',
+                        borderColor: colors.paleBlue,
+                    }}
+                >최신순</button>
+                <button
+                    onClick={() => setSort('OLDEST')}
+                    className="px-2 py-1 rounded-full border"
+                    style={{
+                        background: sort === 'OLDEST' ? colors.paleBlue : '#fff',
+                        color: sort === 'OLDEST' ? colors.navy : '#111827',
+                        borderColor: colors.paleBlue,
+                    }}
+                >오래된순</button>
+            </div>
+        </div>
+    );
+}

--- a/src/simulation/components/ProgressStepper.tsx
+++ b/src/simulation/components/ProgressStepper.tsx
@@ -1,0 +1,43 @@
+import { colors } from '@/styles/colors';
+import type { SimulationStepCode, SimulationStatus } from '../types';
+
+const LABEL: Record<SimulationStepCode, string> = {
+    DOCUMENT_CHECK: '서류검증',
+    CREDIT_CHECK: '신용도확인',
+    BUSINESS_PLAN: '사업계획서 평가',
+    FINAL_REVIEW: '결과 확인',
+};
+
+function colorByStatus(s: SimulationStatus) {
+    switch (s) {
+        case 'COMPLETED': return colors.blue;
+        case 'IN_PROGRESS': return colors.navy;
+        case 'FAILED': return '#EF4444';
+        default: return colors.gray;
+    }
+}
+
+export default function ProgressStepper({
+                                            steps,
+                                        }: {
+    steps: Array<{ stepCode: SimulationStepCode; status: SimulationStatus }>;
+}) {
+    return (
+        <div className="w-full flex items-center gap-3">
+            {steps.map((s, i) => (
+                <div key={s.stepCode} className="flex items-center gap-3 flex-1">
+                    <div className="flex items-center gap-2 w-full">
+                        <div
+                            className="shrink-0 w-8 h-8 rounded-full grid place-items-center text-white text-xs font-semibold"
+                            style={{ background: colorByStatus(s.status) }}
+                        >
+                            {i + 1}
+                        </div>
+                        <div className="text-xs font-medium text-gray-700">{LABEL[s.stepCode]}</div>
+                    </div>
+                    {i < steps.length - 1 && <div className="h-0.5 flex-1" style={{ background: colors.gray }} />}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/simulation/components/QuickTiles.tsx
+++ b/src/simulation/components/QuickTiles.tsx
@@ -1,0 +1,34 @@
+import { colors } from '@/styles/colors';
+import type { MetricScore } from '../types';
+import { useNavigate } from 'react-router-dom';
+
+export default function QuickTiles({ metrics }: { metrics: MetricScore[] }) {
+    const nav = useNavigate();
+
+    const top4 = metrics.slice(0, 4); // 우선 4개 노출(백엔드 연결 시 중요도 순 정렬 추천)
+    const goto = (m: MetricScore) => {
+        // 관련 페이지로 이동(임시 라우팅)
+        const q =
+            m.metricCode === 'DOCUMENT_COMPLETENESS' ? 'document' :
+                m.metricCode === 'CREDIT_SCORE' ? 'credit' :
+                    m.metricCode === 'CASHFLOW_STABILITY' ? 'cashflow' : 'repay';
+        nav(`/guide?tab=${q}`);
+    };
+
+    return (
+        <div className="grid grid-cols-2 gap-3">
+            {top4.map((m) => (
+                <button
+                    key={m.id}
+                    onClick={() => goto(m)}
+                    className="p-4 rounded-2xl bg-white text-left"
+                    style={{ border: `2px solid ${colors.paleBlue}` }}
+                >
+                    <div className="text-sm font-semibold mb-1" style={{ color: colors.navy }}>{m.metricName}</div>
+                    <div className="text-2xl font-extrabold" style={{ color: colors.navy }}>{m.score}</div>
+                    <div className="text-[11px] text-gray-500">값: {m.value}</div>
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/simulation/components/ResultCard.tsx
+++ b/src/simulation/components/ResultCard.tsx
@@ -1,0 +1,61 @@
+import { colors } from '@/styles/colors';
+import { useNavigate } from 'react-router-dom';
+import type { SimulationListItem } from '../types';
+import { fmtDate } from '../utils/format';
+
+const STATUS = {
+    COMPLETED: { label: '완료',  bg: '#DCFCE7', fg: '#047857', bar: '#10B981' },  // green
+    IN_PROGRESS: { label: '진행중', bg: '#FFEDD5', fg: '#C2410C', bar: '#F59E0B' }, // orange
+    FAILED: { label: '중단',  bg: '#FEE2E2', fg: '#B91C1C', bar: '#EF4444' },       // red
+    PENDING: { label: '대기', bg: '#E5E7EB', fg: '#111827', bar: colors.navy },
+} as const;
+
+export default function ResultCard({ item }: { item: SimulationListItem }) {
+    const nav = useNavigate();
+    const st = STATUS[item.status as keyof typeof STATUS] ?? STATUS.PENDING;
+
+    return (
+        <div
+            className="p-4 rounded-3xl shadow-sm bg-white border cursor-pointer"
+            style={{ borderColor: colors.paleBlue }}
+            onClick={() => nav(`/simulation/${item.id}`)}
+        >
+            {/* 상단: 날짜(블루) + 상태 칩(초록/주황/빨강) */}
+            <div className="flex items-center justify-between mb-2">
+                <div className="text-[13px] font-semibold" style={{ color: colors.navy }}>
+                    {fmtDate(item.startedAt)} 시뮬레이션
+                </div>
+                <span
+                    className="text-[11px] px-2 py-1 rounded-full font-semibold"
+                    style={{ background: st.bg, color: st.fg }}
+                >
+          {st.label}
+        </span>
+            </div>
+
+            {/* 진행 바 */}
+            <div className="w-full h-3 rounded-full bg-gray-200 overflow-hidden mb-2">
+                <div className="h-3 rounded-full transition-all" style={{ width: `${item.progressPct}%`, background: st.bar }} />
+            </div>
+
+            {/* 시작 ↔ 예상 (양쪽 정렬) */}
+            <div className="flex items-center justify-between text-sm mb-2">
+                <div className="font-semibold" style={{ color: '#111827' }}>시작: {item.startProbability}%</div>
+                <div className="font-extrabold" style={{ color: st.bar }}>예상: {item.expectedProbability}%</div>
+            </div>
+
+            {/* 태그 */}
+            <div className="mt-1 flex gap-2 flex-wrap">
+                {item.tags.map((t, i) => (
+                    <span
+                        key={i}
+                        className="text-[11px] px-2 py-0.5 rounded-full"
+                        style={{ background: colors.paleBlue, color: colors.navy }}
+                    >
+            {t}
+          </span>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/simulation/components/ScoreGauge.tsx
+++ b/src/simulation/components/ScoreGauge.tsx
@@ -1,0 +1,32 @@
+import { colors } from '@/styles/colors';
+import { clampPct } from '../utils/format';
+
+export default function ScoreGauge({
+                                       label,
+                                       value,
+                                       size = 140,
+                                   }: {
+    label: string;
+    value: number;
+    size?: number;
+}) {
+    const radius = size / 2;
+    const stroke = 10;
+    const v = clampPct(value);
+    const c = 2 * Math.PI * (radius - stroke);
+    const dash = (v / 100) * c;
+
+    return (
+        <div className="flex flex-col items-center">
+            <svg width={size} height={size} className="rotate-[-90deg]">
+                <circle cx={radius} cy={radius} r={radius - stroke} stroke={colors.paleBlue} strokeWidth={stroke} fill="none" />
+                <circle cx={radius} cy={radius} r={radius - stroke} stroke={colors.navy} strokeWidth={stroke}
+                        fill="none" strokeDasharray={`${dash} ${c}`} />
+            </svg>
+            <div className="-mt-8 text-center">
+                <div className="text-3xl font-bold" style={{ color: colors.navy }}>{v}%</div>
+                <div className="text-xs text-gray-500">{label}</div>
+            </div>
+        </div>
+    );
+}

--- a/src/simulation/components/StatusChip.tsx
+++ b/src/simulation/components/StatusChip.tsx
@@ -1,0 +1,16 @@
+import { colors } from '@/styles/colors';
+import type { ScoreCategory } from '../types';
+
+export default function StatusChip({ label, category }: { label: string; category: ScoreCategory }) {
+    const map: Record<ScoreCategory, { bg: string; fg: string }> = {
+        STRENGTH: { bg: colors.paleBlue, fg: colors.navy },
+        NEUTRAL:  { bg: '#E5E7EB',       fg: '#111827' },
+        WEAKNESS: { bg: '#FDE68A',       fg: '#92400E' },
+    };
+    const s = map[category];
+    return (
+        <span className="px-2 py-1 text-xs rounded-full" style={{ background: s.bg, color: s.fg }}>
+      {label}
+    </span>
+    );
+}

--- a/src/simulation/hooks/useMockSimulations.ts
+++ b/src/simulation/hooks/useMockSimulations.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import type { SimulationDetail, SimulationListItem } from '../types';
+import { MOCK_DETAIL, MOCK_LIST } from '../utils/mock';
+
+export function useMockList() {
+    const [data, setData] = useState<SimulationListItem[] | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const t = setTimeout(() => {
+            setData(MOCK_LIST);
+            setLoading(false);
+        }, 350); // 로딩 느낌만
+        return () => clearTimeout(t);
+    }, []);
+
+    return { data, loading };
+}
+
+export function useMockDetail(id?: number | string) {
+    const [data, setData] = useState<SimulationDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const t = setTimeout(() => {
+            const key = Number(id);
+            setData(MOCK_DETAIL[key] ?? null);
+            setLoading(false);
+        }, 350);
+        return () => clearTimeout(t);
+    }, [id]);
+
+    return { data, loading };
+}

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -1,0 +1,2 @@
+export { default as SimulationListPage } from './pages/SimulationList';
+export { default as SimulationDetailPage } from './pages/SimulationDetail';

--- a/src/simulation/layouts/SimulationPageFrame.tsx
+++ b/src/simulation/layouts/SimulationPageFrame.tsx
@@ -1,0 +1,10 @@
+import type {ReactNode} from 'react';
+
+export default function SimulationPageFrame({ children, title }: { children: ReactNode; title?: string }) {
+    return (
+        <div className="max-w-[420px] mx-auto p-4 pb-24">
+            {title && <div className="text-lg font-bold mb-2">{title}</div>}
+            {children}
+        </div>
+    );
+}

--- a/src/simulation/pages/SimulationDetail.tsx
+++ b/src/simulation/pages/SimulationDetail.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import type { SimulationDetail } from '../types';
+import LabeledStepper from '../components/LabeledStepper';
+import DonutGauge from '../components/DonutGauge';
+import ImprovementCard from '../components/ImprovementCard';
+import StatusChip from '../components/StatusChip';
+import { colors } from '@/styles/colors';
+import { MOCK_DETAIL } from '../utils/mock';
+
+export default function SimulationDetailPage() {
+    const { id } = useParams();
+    const [data, setData] = useState<SimulationDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [openImp, setOpenImp] = useState(false);
+
+    useEffect(() => {
+        const t = setTimeout(() => {
+            const key = Number(id);
+            setData(MOCK_DETAIL[key] ?? null);
+            setLoading(false);
+        }, 200);
+        return () => clearTimeout(t);
+    }, [id]);
+
+    const impSummary = useMemo(() => {
+        if (!data) return { sum: 0, max: 0, target: 0 };
+        const sum = data.suggestions.reduce((a, s) => a + s.expectedProbabilityDelta, 0);
+        const target = Math.min(100, data.expectedProbability + sum);
+        const max = Math.max(...data.suggestions.map((s) => s.expectedProbabilityDelta), 0);
+        return { sum, max, target };
+    }, [data]);
+
+    if (loading) return <div className="p-4">로딩 중...</div>;
+    if (!data) return <div className="p-4">데이터가 없습니다.</div>;
+
+    return (
+        <div className="max-w-[420px] mx-auto pb-24">
+            {/* 상단: 스텝퍼(텍스트/뒤로가기 제거) */}
+            <div className="border-b bg-white">
+                <LabeledStepper steps={data.steps.map(s => ({ stepCode: s.stepCode, status: s.status }))} />
+            </div>
+
+            {/* 제목 + 도넛 게이지 + 요약 */}
+            <div className="px-4 mt-3">
+                <div className="rounded-3xl border bg-white p-4 shadow-sm" style={{ borderColor: colors.paleBlue }}>
+                    <div className="text-base font-extrabold mb-3" style={{ color: colors.navy }}>
+                        {data.title}
+                    </div>
+                    <div className="flex gap-4">
+                        <DonutGauge value={data.currentProbability} />
+                        <div className="flex-1 text-sm">
+                            <div className="mb-2">
+                                <b>예상 확률</b>:{' '}
+                                <span className="font-extrabold" style={{ color: colors.navy }}>
+                  {data.expectedProbability}%
+                </span>
+                            </div>
+                            <div className="mb-2"><b>시작 확률</b>: {data.startProbability}%</div>
+                            <div className="mb-2">
+                                <b>상태</b>:{' '}
+                                {data.status === 'COMPLETED' ? '완료' :
+                                    data.status === 'IN_PROGRESS' ? '진행중' :
+                                        data.status === 'FAILED' ? '중단' : '대기'}
+                            </div>
+                            <div className="text-[12px] text-gray-500">
+                                최근 업데이트: {new Date(data.startedAt).toLocaleDateString()}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* 상세 분석 결과(네모 4개는 여기만 유지) */}
+            <div className="px-4 py-1">
+                <h3 className="text-sm font-semibold mb-2" style={{ color: colors.navy }}>상세 분석 결과</h3>
+                <div className="grid grid-cols-2 gap-3">
+                    {data.metrics.map(m => (
+                        <div key={m.id} className="p-3 rounded-2xl border bg-white" style={{ borderColor: colors.paleBlue }}>
+                            <div className="flex items-center justify-between mb-1">
+                                <div className="text-xs font-medium text-gray-800">{m.metricName}</div>
+                                <StatusChip
+                                    label={m.category === 'WEAKNESS' ? '부족' : m.category === 'STRENGTH' ? '양호' : '보통'}
+                                    category={m.category}
+                                />
+                            </div>
+                            <div className="text-2xl font-bold" style={{ color: colors.navy }}>{m.score}</div>
+                            <div className="text-[11px] text-gray-500">값: {m.value}</div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* 개선안: 접기/펼치기 (개선시 도달 가능 확률을 내부로 이동) */}
+            <div className="px-4 py-3">
+                <button
+                    onClick={() => setOpenImp(v => !v)}
+                    className="w-full flex items-center justify-between px-4 py-3 rounded-2xl bg-white border font-semibold"
+                    style={{ borderColor: colors.paleBlue, color: colors.navy }}
+                >
+                    향상 방법과 예상 확률 {openImp ? '닫기' : '자세히 보기'}
+                    <span className={`transition-transform ${openImp ? 'rotate-180' : ''}`}>▼</span>
+                </button>
+
+                {openImp && (
+                    <div className="mt-3 space-y-3">
+                        {/* 개선 시 도달 가능 확률 요약 배너 */}
+                        <div className="rounded-2xl p-4 bg-white border shadow-sm" style={{ borderColor: colors.paleBlue }}>
+                            <div className="text-sm font-semibold mb-1" style={{ color: colors.navy }}>
+                                개선 시 도달 가능 확률
+                            </div>
+                            <div className="flex items-end justify-between">
+                                <div className="text-[13px] text-gray-600">
+                                    현재 예상 {data.expectedProbability}% <span className="mx-2">→</span>
+                                    <b className="text-base" style={{ color: colors.navy }}>최대 {impSummary.target}%</b>
+                                </div>
+                                <div className="text-xs text-gray-500">총 상승 여지: +{impSummary.sum}%p</div>
+                            </div>
+                        </div>
+
+                        {/* 개선안 리스트 */}
+                        {data.suggestions.map(s => <ImprovementCard key={s.id} s={s} />)}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/simulation/pages/SimulationList.tsx
+++ b/src/simulation/pages/SimulationList.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { SimulationListItem } from '../types';
+import ResultCard from '../components/ResultCard';
+import ListFilterBar from '../components/ListFilterBar';
+import { MOCK_LIST } from '../utils/mock';
+
+type Status = 'ALL' | 'COMPLETED' | 'IN_PROGRESS' | 'FAILED' | 'PENDING';
+type Sort = 'LATEST' | 'OLDEST';
+
+export default function SimulationListPage() {
+    const [raw, setRaw] = useState<SimulationListItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [status, setStatus] = useState<Status>('ALL');
+    const [sort, setSort] = useState<Sort>('LATEST');
+
+    useEffect(() => {
+        const t = setTimeout(() => {
+            setRaw(MOCK_LIST);
+            setLoading(false);
+        }, 200);
+        return () => clearTimeout(t);
+    }, []);
+
+    const list = useMemo(() => {
+        let arr = raw.slice();
+        if (status !== 'ALL') arr = arr.filter((i) => i.status === status);
+        arr.sort((a, b) =>
+            sort === 'LATEST'
+                ? +new Date(b.startedAt) - +new Date(a.startedAt)
+                : +new Date(a.startedAt) - +new Date(b.startedAt)
+        );
+        return arr;
+    }, [raw, status, sort]);
+
+    return (
+        <div className="max-w-[420px] mx-auto p-4">
+            <ListFilterBar status={status} setStatus={setStatus} sort={sort} setSort={setSort} />
+            {loading && <div>로딩 중...</div>}
+            {!loading && list.length === 0 && <div className="text-sm text-gray-500">해당 조건의 내역이 없습니다.</div>}
+            <div className="space-y-3">
+                {list.map((it) => <ResultCard key={it.id} item={it} />)}
+            </div>
+        </div>
+    );
+}

--- a/src/simulation/styles/tokens.ts
+++ b/src/simulation/styles/tokens.ts
@@ -1,0 +1,4 @@
+import { colors } from '@/styles/colors';
+
+export const cardBorder = { border: `1px solid ${colors.paleBlue}` };
+export const sectionTitle = { color: colors.navy };

--- a/src/simulation/types/index.ts
+++ b/src/simulation/types/index.ts
@@ -1,0 +1,56 @@
+export type SimulationStatus = 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+export type SimulationStepCode = 'DOCUMENT_CHECK' | 'CREDIT_CHECK' | 'BUSINESS_PLAN' | 'FINAL_REVIEW';
+export type ScoreCategory = 'STRENGTH' | 'NEUTRAL' | 'WEAKNESS';
+
+export interface SimulationListItem {
+    id: number;
+    title: string;
+    startedAt: string;             // ISO
+    expectedProbability: number;   // 0~100
+    startProbability: number;      // 0~100
+    progressPct: number;           // 0~100
+    status: SimulationStatus;
+    tags: string[];
+}
+
+export interface SimulationStep {
+    id: number;
+    stepCode: SimulationStepCode;
+    status: SimulationStatus;
+    score?: number | null;
+    grade?: string | null;
+    notes?: string | null;
+}
+
+export interface MetricScore {
+    id: number;
+    metricCode: string;
+    metricName: string;
+    category: ScoreCategory;
+    value: number;   // 원시값/정규화값 아무거나
+    score: number;   // 0~100
+}
+
+export interface ImprovementSuggestion {
+    id: number;
+    targetMetricCode: string;
+    targetMetricName: string;
+    currentValue: number | null;
+    suggestedValue: number | null;
+    expectedProbabilityDelta: number; // +%p
+    rationale: string;
+}
+
+export interface SimulationDetail {
+    id: number;
+    title: string;
+    status: SimulationStatus;
+    startedAt: string;
+    completedAt?: string | null;
+    startProbability: number;
+    currentProbability: number;
+    expectedProbability: number;
+    steps: SimulationStep[];
+    metrics: MetricScore[];
+    suggestions: ImprovementSuggestion[];
+}

--- a/src/simulation/utils/format.ts
+++ b/src/simulation/utils/format.ts
@@ -1,0 +1,4 @@
+export const fmtDate = (iso: string) =>
+    new Date(iso).toLocaleDateString();
+
+export const clampPct = (n: number) => Math.max(0, Math.min(100, Math.round(n)));

--- a/src/simulation/utils/mock.ts
+++ b/src/simulation/utils/mock.ts
@@ -1,0 +1,110 @@
+import type { SimulationDetail, SimulationListItem } from '../types';
+
+export const MOCK_LIST: SimulationListItem[] = [
+    {
+        id: 101,
+        title: '2024.10.25 시뮬레이션',
+        startedAt: '2024-10-25T10:00:00Z',
+        expectedProbability: 85,
+        startProbability: 50,
+        progressPct: 100,
+        status: 'COMPLETED',
+        tags: ['#신용등급보완', '#매출증대'],
+    },
+    {
+        id: 95,
+        title: '2024.10.20 시뮬레이션',
+        startedAt: '2024-10-20T11:30:00Z',
+        expectedProbability: 70,
+        startProbability: 40,
+        progressPct: 75,
+        status: 'IN_PROGRESS',
+        tags: ['#서류보완', '#사업계획서'],
+    },
+    {
+        id: 77,
+        title: '2024.10.01 시뮬레이션',
+        startedAt: '2024-10-01T09:10:00Z',
+        expectedProbability: 0,
+        startProbability: 0,
+        progressPct: 0,
+        status: 'FAILED',
+        tags: ['#검토중단'],
+    },
+];
+
+export const MOCK_DETAIL: Record<number, SimulationDetail> = {
+    101: {
+        id: 101,
+        title: '2024.10.25 시뮬레이션',
+        status: 'COMPLETED',
+        startedAt: '2024-10-25T10:00:00Z',
+        completedAt: '2024-10-25T10:15:00Z',
+        startProbability: 50,
+        currentProbability: 78,
+        expectedProbability: 85,
+        steps: [
+            { id: 1, stepCode: 'DOCUMENT_CHECK', status: 'COMPLETED', score: 80, grade: 'B', notes: '필수 서류 충족' },
+            { id: 2, stepCode: 'CREDIT_CHECK', status: 'COMPLETED', score: 90, grade: 'A', notes: '연체 이력 없음' },
+            { id: 3, stepCode: 'BUSINESS_PLAN', status: 'COMPLETED', score: 75, grade: 'B', notes: '매출 추정 보수적' },
+            { id: 4, stepCode: 'FINAL_REVIEW', status: 'COMPLETED', score: 0, grade: null, notes: '자동 평가 완료' },
+        ],
+        metrics: [
+            { id: 11, metricCode: 'CREDIT_SCORE',           metricName: '신용등급',       category: 'STRENGTH', value: 820,  score: 90 },
+            { id: 12, metricCode: 'DEBT_RATIO',             metricName: '부채비율',       category: 'NEUTRAL',  value: 42.5, score: 70 },
+            { id: 13, metricCode: 'CASHFLOW_STABILITY',     metricName: '현금흐름 안정성', category: 'NEUTRAL',  value: 67.2, score: 68 },
+            { id: 14, metricCode: 'DOCUMENT_COMPLETENESS',  metricName: '서류완성도',     category: 'WEAKNESS', value: 75.0, score: 60 },
+        ],
+        suggestions: [
+            {
+                id: 21,
+                targetMetricCode: 'DOCUMENT_COMPLETENESS',
+                targetMetricName: '서류완성도',
+                currentValue: 75,
+                suggestedValue: 90,
+                expectedProbabilityDelta: 15,
+                rationale: '필수 서류 누락 항목 보완 시 확률이 크게 상승합니다.',
+            },
+            {
+                id: 22,
+                targetMetricCode: 'DEBT_RATIO',
+                targetMetricName: '부채비율',
+                currentValue: 42.5,
+                suggestedValue: 35,
+                expectedProbabilityDelta: 6,
+                rationale: '단기부채 일부 상환 시 리스크가 낮아집니다.',
+            },
+        ],
+    },
+    95: {
+        id: 95,
+        title: '2024.10.20 시뮬레이션',
+        status: 'IN_PROGRESS',
+        startedAt: '2024-10-20T11:30:00Z',
+        completedAt: null,
+        startProbability: 40,
+        currentProbability: 62,
+        expectedProbability: 70,
+        steps: [
+            { id: 1, stepCode: 'DOCUMENT_CHECK', status: 'COMPLETED', score: 70, grade: 'B', notes: '사업자등록증 보완 필요' },
+            { id: 2, stepCode: 'CREDIT_CHECK', status: 'COMPLETED', score: 78, grade: 'B', notes: '카드연체 1건(과거) 확인' },
+            { id: 3, stepCode: 'BUSINESS_PLAN', status: 'IN_PROGRESS', score: null, grade: null, notes: '추가자료 검토중' },
+            { id: 4, stepCode: 'FINAL_REVIEW', status: 'PENDING', score: null, grade: null, notes: null },
+        ],
+        metrics: [
+            { id: 11, metricCode: 'CREDIT_SCORE',           metricName: '신용등급',       category: 'NEUTRAL',  value: 765, score: 78 },
+            { id: 14, metricCode: 'DOCUMENT_COMPLETENESS',  metricName: '서류완성도',     category: 'WEAKNESS', value: 68,  score: 58 },
+        ],
+        suggestions: [
+            {
+                id: 33,
+                targetMetricCode: 'DOCUMENT_COMPLETENESS',
+                targetMetricName: '서류완성도',
+                currentValue: 68,
+                suggestedValue: 85,
+                expectedProbabilityDelta: 10,
+                rationale: '매출증빙 자료 추가 제출 권장.',
+            },
+        ],
+    },
+};

--- a/src/simulation/utils/progress.ts
+++ b/src/simulation/utils/progress.ts
@@ -1,0 +1,15 @@
+import { colors } from '@/styles/colors';
+import type { SimulationStatus } from '../types';
+
+export const statusLabel: Record<SimulationStatus, string> = {
+    PENDING: '대기',
+    IN_PROGRESS: '진행중',
+    COMPLETED: '완료',
+    FAILED: '실패',
+};
+
+export const progressBarColor = (pct: number) => {
+    if (pct >= 100) return colors.blue;
+    if (pct >= 75) return '#F59E0B'; // amber-500
+    return colors.navy;
+};


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약
- 홈 화면 히어로 영역 + 검색바, 대형 캐러셀(도트 포함), 섹션 카드(추천/커뮤니티) 구현
- 시뮬레이션 **결과 리스트** 카드 리디자인(상태별 색상, 시작↔예상 좌우 배치) + 상단 필터/정렬 바 추가
- 시뮬레이션 **상세** 상단 스텝퍼(라벨형), 도넛 게이지, 상세 분석 카드(2열), 개선안 접기/펼치기 및
  ‘**개선 시 도달 가능 확률**’을 펼침 내부로 이동
- 전 구간 **MOCK 데이터**로 동작 (백엔드 연동 전)

## 📖 작업 내용
### 홈 (`/`)
- 헤더 비표시(앱 크롬에서 홈 경로일 때 숨김)
- **HomeHero**: 브랜드(가이드온) + 검색바 히어로 섹션 추가
- **GuideStatusCarousel**: 대형 슬라이드 카드 4개 + 인디케이터 도트
- **시뮬 내역** 통계(참여/진행/평균 예상), **추천**, **커뮤니티** 섹션 타이틀과 리치 카드 추가

주요 파일
- `src/home/components/HomeHero.tsx` **[신규]**
- `src/home/components/GuideStatusCarousel.tsx`, `GuideStatusSlideCard.tsx`
- `src/home/components/RichLinkCard.tsx`, `HomeGreeting.tsx`
- `src/home/pages/Home.tsx` **[교체]**
- `src/home/hooks/useHomeMock.ts`, `src/home/utils/mock.ts`

### 시뮬 결과 리스트 (`/simulation`)
- 상단 **필터/정렬 바**(전체/완료/진행중/중단 + 최신/오래된순)
- 카드 리디자인
  - 날짜·상태 칩(완료=초록, 진행중=주황, 중단=빨강)
  - 진행 바 색상 상태에 따라 변경
  - **시작% ↔ 예상%** 양 끝 정렬
  - 태그 칩 정리
- Mock 목록/정렬/필터 로직

주요 파일
- `src/simulation/components/ListFilterBar.tsx` **[신규]**
- `src/simulation/components/ResultCard.tsx`
- `src/simulation/pages/SimulationList.tsx` **[교체]**
- `src/simulation/utils/mock.ts`

### 시뮬 상세 (`/simulation/:id`)
- 상단 **LabeledStepper**(숫자 위에 라벨, 뒤로가기 텍스트 제거)
- **DonutGauge**(현재 승인 확률)
- **상세 분석 결과**: 2열 카드 + 카테고리 칩
- 개선안 영역
  - 버튼 클릭 시 펼침
  - **개선 시 도달 가능 확률** 요약 배너를 **펼침 내부**로 이동
  - 개선안 카드 리스트
- 위쪽에 있던 4개 네모 타일(빠른 진단)은 제거하고, **‘상세 분석 결과’ 아래 카드만 유지**

주요 파일
- `src/simulation/components/LabeledStepper.tsx`, `DonutGauge.tsx`
- `src/simulation/components/ImprovementCard.tsx`, `StatusChip.tsx`
- `src/simulation/pages/SimulationDetail.tsx` **[교체]**

### 공통/스타일
- `App.tsx` : 홈 경로에서 헤더 숨김 유지, 라우팅 연결
- `src/styles/colors.ts` 사용(테마 반영)

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료 (홈/리스트/상세 내비게이션 포함)
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다. (컴포넌트 구조/모의 데이터 위치)
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항
- 홈 캐러셀 **자동 슬라이드**/스와이프 힌트 필요 여부?
- 리스트 필터 기본값(현재는 `전체/최신순`) 확정 필요
- 상세 페이지 **개선안 계산식**(현재는 `sum(Delta)`로 최대치 산출) 백엔드에서 제공 예정인지?
- 홈 검색바 기능(엔드포인트/검색 범위) 정의 필요

## 🚧 남은 일 / 임시 사항
- 현재 전부 **MOCK 데이터 임시** 동작입니다.
  - 백엔드 API 스펙 확정 후 **연동 작업 필요**
  - 로딩/에러/빈 상태 세분화(스켈레톤/토스트)
- 상세 디자인 추가 보정
  - 도넛 게이지 수치/색상 임계값 확정
  - 카드 간격/폰트 크기 최종 스펙 반영
  - 접근성(키보드 포커스/aria) 점검
- 단위/통합 테스트 보완

## 🔗 관련 이슈
- closes **#11**
